### PR TITLE
toss the `flex justify-center` so images are left justified

### DIFF
--- a/packages/web-client/src/components/notebook/RichOutput.tsx
+++ b/packages/web-client/src/components/notebook/RichOutput.tsx
@@ -130,7 +130,7 @@ export const RichOutput: React.FC<RichOutputProps> = ({
       case 'image/svg+xml':
       case 'image/svg':
         return (
-          <div className="flex justify-center py-2">
+          <div className="py-2">
             <div
               className="max-w-full"
               dangerouslySetInnerHTML={{ __html: outputData[mediaType] || '' }}


### PR DESCRIPTION
<img width="892" alt="image" src="https://github.com/user-attachments/assets/a33eef77-247d-4e2d-828c-f28bf91b1ad7" />
