### PR TITLE
Fix cell creation to inherit parent cell type and navigate properly with Shift+Enter

### DIFF
--- a/packages/web-client/src/components/notebook/AiCell.tsx
+++ b/packages/web-client/src/components/notebook/AiCell.tsx
@@ -162,11 +162,13 @@ export const AiCell: React.FC<AiCellProps> = ({
 
     // Handle execution shortcuts
     if (e.key === 'Enter' && e.shiftKey) {
-      // Shift+Enter: Run cell and move to next (create new cell)
+      // Shift+Enter: Run cell and move to next (or create new cell if at end)
       e.preventDefault()
       updateSource()
       executeAiPrompt()
-      onAddCell() // Move to next cell
+      if (onFocusNext) {
+        onFocusNext() // Move to next cell (or create new if at end)
+      }
     } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       // Ctrl/Cmd+Enter: Run cell but stay in current cell
       e.preventDefault()

--- a/packages/web-client/src/components/notebook/Cell.tsx
+++ b/packages/web-client/src/components/notebook/Cell.tsx
@@ -204,13 +204,15 @@ export const Cell: React.FC<CellProps> = ({
 
     // Handle execution shortcuts
     if (e.key === 'Enter' && e.shiftKey) {
-      // Shift+Enter: Run cell and move to next (create new cell)
+      // Shift+Enter: Run cell and move to next (or create new cell if at end)
       e.preventDefault()
       updateSource()
       if (cell.cellType === 'code') {
         executeCell()
       }
-      onAddCell() // Move to next cell
+      if (onFocusNext) {
+        onFocusNext() // Move to next cell (or create new if at end)
+      }
     } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       // Ctrl/Cmd+Enter: Run cell but stay in current cell
       e.preventDefault()

--- a/packages/web-client/src/components/notebook/NotebookViewer.tsx
+++ b/packages/web-client/src/components/notebook/NotebookViewer.tsx
@@ -147,8 +147,10 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({ onNewNotebook })
       const nextCell = sortedCells[currentIndex + 1]
       setFocusedCellId(nextCell.id)
     } else {
-      // At the last cell, create a new one
-      addCell(currentCellId)
+      // At the last cell, create a new one with same cell type (but never raw)
+      const currentCell = sortedCells[currentIndex]
+      const newCellType = currentCell.cellType === 'raw' ? 'code' : currentCell.cellType
+      addCell(currentCellId, newCellType)
     }
   }, [cells, addCell])
 
@@ -414,7 +416,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({ onNewNotebook })
             <Cell
               key={cell.id}
               cell={cell}
-              onAddCell={() => addCell(cell.id)}
+              onAddCell={() => addCell(cell.id, cell.cellType === 'raw' ? 'code' : cell.cellType)}
               onDeleteCell={() => deleteCell(cell.id)}
               onMoveUp={() => moveCell(cell.id, 'up')}
               onMoveDown={() => moveCell(cell.id, 'down')}

--- a/packages/web-client/src/components/notebook/SqlCell.tsx
+++ b/packages/web-client/src/components/notebook/SqlCell.tsx
@@ -121,11 +121,13 @@ export const SqlCell: React.FC<SqlCellProps> = ({
     }
 
     if (e.key === 'Enter' && e.shiftKey) {
-      // Shift+Enter: Run query and move to next cell
+      // Shift+Enter: Run query and move to next (or create new cell if at end)
       e.preventDefault()
       updateQuery()
       executeQuery()
-      onAddCell()
+      if (onFocusNext) {
+        onFocusNext() // Move to next cell (or create new if at end)
+      }
     } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       // Ctrl/Cmd+Enter: Run query but stay in current cell
       e.preventDefault()


### PR DESCRIPTION
### Problem
- **Shift+Enter always created new cells** even when there was already a cell below - it should move to the next existing cell instead
- **New cells always defaulted to code type** regardless of the parent cell type when using + button or Shift+Enter
- **Raw cells could potentially create new raw cells** (should never happen - raw is legacy only)

### Solution
- **Shift+Enter now moves to next cell when one exists**, only creating a new cell when at the last cell
- **New cells inherit the type from their parent cell** (code → code, AI → AI, SQL → SQL, markdown → markdown)
- **Raw cells are prevented from creating new raw cells** - they default to creating code cells instead
- Applied consistently across all cell creation methods:
  - + button on cells  
  - Shift+Enter when at the last cell