### PR TITLE
feat: Upgrade to Node.js v24+ for full HTTPS support in Pyodide

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,6 +14,7 @@
 
 #### Python Execution
 - **Basic Python execution** - Code cells run Python via Pyodide (manual kernel startup)
+- **HTTPS support** - Full HTTPS requests work with Node.js v24+ (requests, pandas.read_csv, urllib3)
 - **Error handling** - Python exceptions properly captured and displayed
 - **Text output** - print() statements and basic stdout/stderr capture
 - **Execution queue** - Proper job queuing and status tracking

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A real-time collaborative notebook system built on LiveStore, focusing on seamle
 
 **Current Status: Working Prototype** - Core collaborative editing, Python execution, and basic AI integration functional. Rich outputs need verification.
 
+## Prerequisites
+
+- **Node.js v24+** - Required for WebAssembly stack switching support in Pyodide
+- **pnpm** - Package manager for workspace dependencies
+- **2GB+ RAM** - Recommended for Python execution and package caching
+
 ## What Makes Anode Different
 
 - **Real-time collaboration** built on event sourcing (LiveStore)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -137,7 +137,7 @@ display(Markdown('**Bold text**'))
 ### Test Environment Setup
 
 **CI Requirements:**
-- Node.js 18+ environment
+- Node.js 24+ environment
 - Sufficient memory for Pyodide (>1GB)
 - Timeout handling for slow tests
 - Artifact collection for failed tests

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Anode - real-time collaborative notebook system with rich outputs",
   "engines": {
-    "node": ">=23.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "pnpm --recursive --filter='@anode/*' build",


### PR DESCRIPTION
## 🎯 Problem Solved

Pyodide HTTPS requests were failing with `URLError: <urlopen error unknown url type: https>` and urllib3 requiring experimental WebAssembly flags:

```
Connection aborted.', HTTPException('urllib3 only works in Node.js with pyodide.runPythonAsync and requires the flag --experimental-wasm-stack-switching in versions of node <24.
```

This blocked essential functionality like `pandas.read_csv()` with HTTPS URLs and `requests` library usage.

## 🚀 Solution

Upgrade Node.js requirement to v24+ which provides native WebAssembly stack switching support, eliminating the need for experimental flags.

## ✅ What Now Works

All HTTPS operations in Python notebooks:

```python
# Direct pandas HTTPS reading - now works!
df = pd.read_csv('https://docs.google.com/spreadsheets/d/abc123/export?format=csv')

# requests library HTTPS - works!
import requests
response = requests.get('https://api.example.com/data')

# urllib3 HTTPS - works!
import urllib3
http = urllib3.PoolManager()
resp = http.request('GET', 'https://httpbin.org/json')

## Context

Node.js v24 includes native WebAssembly JavaScript Promise Integration (JSPI) and stack switching support that Pyodide relies on for proper networking. Previous versions required `--experimental-wasm-stack-switching` flag.

This change aligns with Pyodide's official recommendations and modern JavaScript runtime capabilities.