### PR TITLE
Fix materializer hash mismatch by making Execution* materializers deterministic

### DIFF
--- a/packages/dev-server-kernel-ls-client/src/kernel-adapter.ts
+++ b/packages/dev-server-kernel-ls-client/src/kernel-adapter.ts
@@ -565,6 +565,7 @@ async function processExecution(queueEntry: any) {
     const hasErrors = outputs.some(o => o.type === "error");
     store.commit(events.executionCompleted({
       queueId: queueEntry.id,
+      cellId: queueEntry.cellId,
       status: hasErrors ? "error" : "success",
       error: hasErrors ? "Execution completed with errors" : undefined,
     }));
@@ -580,6 +581,7 @@ async function processExecution(queueEntry: any) {
     try {
       store.commit(events.executionCompleted({
         queueId: queueEntry.id,
+        cellId: queueEntry.cellId,
         status: "error",
         error: error instanceof Error ? error.message : String(error),
       }));
@@ -624,6 +626,7 @@ assignedWorkSubscription = store.subscribe(assignedWorkQuery$ as any, {
           try {
             store.commit(events.executionCompleted({
               queueId: queueEntry.id,
+              cellId: queueEntry.cellId,
               status: "error",
               error: error instanceof Error ? error.message : String(error),
             }));

--- a/packages/dev-server-kernel-ls-client/test/kernel-adapter.test.ts
+++ b/packages/dev-server-kernel-ls-client/test/kernel-adapter.test.ts
@@ -206,6 +206,7 @@ describe('Kernel Adapter', () => {
       // Complete execution
       store.commit(events.executionCompleted({
         queueId,
+        cellId,
         status: 'success',
       }))
 
@@ -384,6 +385,7 @@ describe('Kernel Adapter', () => {
         if (i % 2 === 0) {
           store.commit(events.executionCompleted({
             queueId,
+            cellId: `cell-${i}`,
             status: 'success'
           }))
         }

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -120,6 +120,7 @@ export const mockEvents = {
     name: "v1.ExecutionCompleted",
     args: {
       queueId: mockExecutionQueueEntry.id,
+      cellId: mockCellData.id,
       status: "success" as const,
       error: null,
     },

--- a/test/integration/execution-flow.test.ts
+++ b/test/integration/execution-flow.test.ts
@@ -185,6 +185,7 @@ describe.skip("End-to-End Execution Flow", () => {
       store.commit(
         events.executionCompleted({
           queueId,
+          cellId,
           status: "success",
         }),
       );
@@ -303,6 +304,7 @@ describe.skip("End-to-End Execution Flow", () => {
       store.commit(
         events.executionCompleted({
           queueId,
+          cellId,
           status: "error",
           error: "ValueError: Test error",
         }),
@@ -423,6 +425,7 @@ describe.skip("End-to-End Execution Flow", () => {
         store.commit(
           events.executionCompleted({
             queueId,
+            cellId: cellIds[i],
             status: "success",
           }),
         );

--- a/test/integration/reactivity-debugging.test.ts
+++ b/test/integration/reactivity-debugging.test.ts
@@ -168,6 +168,7 @@ describe("Reactivity Debugging", () => {
       store.commit(
         events.executionCompleted({
           queueId: "multi-sub-queue",
+          cellId: "multi-sub-cell",
           status: "success",
         }),
       );


### PR DESCRIPTION
- Add `cellId` to `ExecutionCompleted` and `ExecutionCancelled` event schemas
- Remove `ctx.query()` calls from materializers to make them pure functions
- Update all event commits to include cellId in the payload
- This fixes `LiveStore.UnexpectedError` about materializer hash mismatch

The issue was that materializers were using `ctx.query()` to look up `cellId` during materialization, making them non-deterministic. LiveStore requires materializers to be pure functions without side effects -- all data must be passed via the event payload.