### PR TITLE
More materializers

### DIFF
--- a/packages/dev-server-kernel-ls-client/src/kernel-adapter.ts
+++ b/packages/dev-server-kernel-ls-client/src/kernel-adapter.ts
@@ -501,6 +501,7 @@ async function processExecution(queueEntry: any) {
     // Mark execution as started
     store.commit(events.executionStarted({
       queueId: queueEntry.id,
+      cellId: queueEntry.cellId,
       kernelSessionId: SESSION_ID,
     }));
 

--- a/packages/dev-server-kernel-ls-client/test/kernel-adapter.test.ts
+++ b/packages/dev-server-kernel-ls-client/test/kernel-adapter.test.ts
@@ -200,6 +200,7 @@ describe('Kernel Adapter', () => {
       // Start execution
       store.commit(events.executionStarted({
         queueId,
+        cellId,
         kernelSessionId: sessionId,
       }))
 

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -113,6 +113,7 @@ export const mockEvents = {
     name: "v1.ExecutionStarted",
     args: {
       queueId: mockExecutionQueueEntry.id,
+      cellId: mockCellData.id,
       kernelSessionId: mockKernelSession.sessionId,
     },
   },

--- a/test/integration/execution-flow.test.ts
+++ b/test/integration/execution-flow.test.ts
@@ -393,7 +393,7 @@ describe.skip("End-to-End Execution Flow", () => {
       });
 
       // Assign executions to different sessions
-      cells.forEach(({ queueId }, index) => {
+      cells.forEach(({ queueId, cellId }, index) => {
         const sessionIndex = index % sessions.length;
         const { sessionId: sid } = sessions[sessionIndex];
 
@@ -407,7 +407,7 @@ describe.skip("End-to-End Execution Flow", () => {
         store.commit(
           events.executionStarted({
             queueId,
-            cellId: cellIds[i],
+            cellId,
             kernelSessionId: sid,
           }),
         );
@@ -428,7 +428,7 @@ describe.skip("End-to-End Execution Flow", () => {
         store.commit(
           events.executionCompleted({
             queueId,
-            cellId: cellIds[i],
+            cellId,
             status: "success",
           }),
         );

--- a/test/integration/execution-flow.test.ts
+++ b/test/integration/execution-flow.test.ts
@@ -156,6 +156,7 @@ describe.skip("End-to-End Execution Flow", () => {
       store.commit(
         events.executionStarted({
           queueId,
+          cellId,
           kernelSessionId: sessionId,
         }),
       );
@@ -277,6 +278,7 @@ describe.skip("End-to-End Execution Flow", () => {
       store.commit(
         events.executionStarted({
           queueId,
+          cellId,
           kernelSessionId: sessionId,
         }),
       );
@@ -405,6 +407,7 @@ describe.skip("End-to-End Execution Flow", () => {
         store.commit(
           events.executionStarted({
             queueId,
+            cellId: cellIds[i],
             kernelSessionId: sid,
           }),
         );
@@ -663,6 +666,7 @@ describe.skip("End-to-End Execution Flow", () => {
       store.commit(
         events.executionStarted({
           queueId,
+          cellId,
           kernelSessionId: sessionId,
         }),
       );

--- a/test/integration/reactivity-debugging.test.ts
+++ b/test/integration/reactivity-debugging.test.ts
@@ -99,6 +99,7 @@ describe("Reactivity Debugging", () => {
       store.commit(
         events.executionStarted({
           queueId,
+          cellId,
           kernelSessionId: sessionId,
         }),
       );


### PR DESCRIPTION
Fixes #34.

- Add `cellId` to `ExecutionStarted` event schema
- Remove `ctx.query()` call from `ExecutionStarted` materializer
- Update all cell event commits to include `cellId` in the payload

This fixes another potential source of materializer hash mismatches that
could cause LiveStore to shut down unexpectedly. All materializers are
now deterministic and side-effect free.