### PR TITLE
Update docs to reflect kernel restart bug (#34) resolution

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -60,7 +60,7 @@
 
 ## Current Work State
 
-**Status**: 🚧 **Working Prototype** - Core collaborative editing, Python execution, and basic AI integration functional, rich outputs need verification
+**Status**: 🚧 **Working Prototype** - Core collaborative editing, Python execution, and basic AI integration functional, rich outputs need verification. Major kernel restart bug (#34) resolved.
 
 ### What's Actually Working ✅
 
@@ -72,6 +72,7 @@
 
 #### Python Execution
 - **Basic Python execution** - Code cells run Python via Pyodide (manual kernel startup)
+- **Kernel session reliability** - Fixed materializer side effects causing restart failures (#34) ✅
 - **Error handling** - Python exceptions properly captured and displayed
 - **Text output** - print() statements and basic stdout/stderr capture
 - **Execution queue** - Proper job queuing and status tracking
@@ -144,7 +145,7 @@
 - Streaming responses for better UX
 - Multi-turn conversation support
 
-### Priority 3: MCP Integration Foundation 🔮 LONG-TERM
+### Priority 4: MCP Integration Foundation 🔮 LONG-TERM
 **Status**: 🎯 **Architecture planning**
 
 **Goal**: Connect to Model Context Protocol providers for extensible AI tooling
@@ -169,23 +170,26 @@
 **Estimated effort**: 1-2 months (after tool calling foundation)
 **Impact**: Enables unlimited AI tool extensibility through Python ecosystem
 
-### Priority 4: Auto Kernel Management (High Impact)
+### Priority 3: Auto Kernel Management (High Impact) 🚀 UPGRADED
 **Current friction**: Manual `NOTEBOOK_ID=xyz pnpm dev:kernel` per notebook
 
 **Goal**: One-click notebook startup with automatic kernel lifecycle
+
+**Foundation now solid**: With kernel restart bug (#34) fixed, automated management is much more viable
 
 **Next actions**:
 - Modify `pnpm dev` to auto-spawn kernels per notebook
 - Add kernel health monitoring and restart capability
 - Better error messages when kernels fail or disconnect
+- Leverage fixed kernel session reliability for robust auto-restart
 
 **Files to modify**:
 - Root `package.json` - Update dev script
 - `packages/web-client/src/components/notebook/NotebookViewer.tsx` - Status display
 - Add kernel process management utilities
 
-**Estimated effort**: 2-3 hours
-**Impact**: Removes major user friction
+**Estimated effort**: 2-3 hours (reduced due to fixed foundation)
+**Impact**: Removes major user friction + leverages recent reliability improvements
 
 ### Priority 5: Rich Output Verification (Medium)
 **Current state**: Code exists but integration unclear
@@ -262,7 +266,11 @@ pnpm test               # Full test suite (27 passing, 13 skipped)
 - **Performance claims unverified**: Need integration tests to validate speed/output claims
 
 ### Known Critical Issues
-- **🐛 Kernel Restart Bug**: 3rd+ kernel sessions fail to receive work assignments due to LiveStore web client shutdowns when multiple terminated sessions accumulate (see https://github.com/rgbkrk/anode/issues/34 and branch `annoying-multiples-bug`)
+- **None currently identified** - Major kernel restart bug (#34) resolved by cleaning up side effects in materializers
+
+### Recent Fixes ✅
+- **Kernel restart bug (#34)** - Fixed materializer side effects that caused 3rd+ kernel sessions to fail work assignments
+- **LiveStore web client shutdowns** - Resolved accumulation of terminated sessions causing kernel communication failures
 
 ### Schema & Architecture Notes
 - All packages use direct TypeScript imports: `../../../shared/schema.js`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Vision**: A real-time collaborative notebook system enabling seamless AI ↔ Python ↔ User interactions through local-first architecture.
 
-**Current Status**: Core prototype with collaborative editing, basic Python execution, and AI integration with context awareness working. AI tool calling and rich outputs in active development.
+**Current Status**: Core prototype with collaborative editing, basic Python execution, and AI integration with context awareness working. Major kernel restart bug (#34) resolved by fixing materializer side effects. AI tool calling and rich outputs in active development.
 
 ## Foundation Complete ✅
 
@@ -10,6 +10,7 @@
 - **LiveStore event-sourcing** - Real-time collaborative state management
 - **Direct TypeScript schema** - No build complexity, full type safety
 - **Reactive execution queue** - Kernel work detection without polling
+- **Reliable kernel sessions** - Fixed materializer side effects, stable multi-session operation
 - **Cell management** - Create, edit, move, delete with proper state sync
 - **Basic Python execution** - Code cells run via Pyodide (manual kernel startup)
 
@@ -54,6 +55,7 @@
 ### Automated Kernel Management
 **Goal**: Remove manual `NOTEBOOK_ID=xyz pnpm dev:kernel` friction
 
+- [x] **Kernel session reliability** - Fixed materializer side effects causing restart failures (#34)
 - [ ] **Auto-spawning kernels** - One-click notebook startup
 - [ ] **Kernel health monitoring** - Detect failures and restart
 - [ ] **Better status UI** - Clear feedback on kernel state


### PR DESCRIPTION
- Update AGENTS.md with critical materializer determinism requirements
- Add detailed section about `ctx.query()` being forbidden in materializers
- Document specific commits (`6e0fb4f`, `a1bf20d`) that fixed the issue
- Provide code examples showing wrong vs correct materializer patterns
- Update `HANDOFF.md` to remove bug from critical issues, add to recent fixes
- Update `ROADMAP.md` to mark kernel session reliability as completed
- Upgrade auto kernel management priority due to more solid foundation

This guides future developers away from accidentally reintroducing side effects in materializers that would cause LiveStore hash mismatches and kernel failures.