### PR TITLE
Implement Dual-Mode ANSI Handling: Clean for AI, Colored for Users

### DIFF
--- a/packages/pyodide-runtime-agent/package.json
+++ b/packages/pyodide-runtime-agent/package.json
@@ -25,7 +25,8 @@
     "@livestore/livestore": "catalog:",
     "@livestore/sync-cf": "catalog:",
     "pyodide": "catalog:",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "strip-ansi": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/pyodide-runtime-agent/src/cache-utils.ts
+++ b/packages/pyodide-runtime-agent/src/cache-utils.ts
@@ -22,6 +22,7 @@ export function getEssentialPackages(): string[] {
     "scikit-learn", // Machine learning
     "altair",     // Statistical visualization
     "geopandas",  // Geospatial data analysis
+    "rich",       // Beautiful terminal output with colors
   ];
 }
 

--- a/packages/pyodide-runtime-agent/src/pyodide-kernel.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-kernel.ts
@@ -51,6 +51,59 @@ export class PyodideKernel {
         },
       });
 
+      // Configure terminal environment for color support
+      console.log(`🎨 Configuring terminal environment for rich colors...`);
+      this.pyodide.runPython(`
+import os
+import sys
+
+# Set environment variables to enable terminal colors
+os.environ['TERM'] = 'xterm-256color'
+os.environ['FORCE_COLOR'] = '1'
+os.environ['COLORTERM'] = 'truecolor'
+os.environ['CLICOLOR'] = '1'
+os.environ['CLICOLOR_FORCE'] = '1'
+
+# Mock sys.stdout.isatty() to return True for color detection
+class ColorfulStdout:
+    def __init__(self, original):
+        self._original = original
+
+    def __getattr__(self, name):
+        return getattr(self._original, name)
+
+    def isatty(self):
+        return True
+
+    def write(self, text):
+        return self._original.write(text)
+
+    def flush(self):
+        return self._original.flush()
+
+class ColorfulStderr:
+    def __init__(self, original):
+        self._original = original
+
+    def __getattr__(self, name):
+        return getattr(self._original, name)
+
+    def isatty(self):
+        return True
+
+    def write(self, text):
+        return self._original.write(text)
+
+    def flush(self):
+        return self._original.flush()
+
+# Replace stdout and stderr with colorful versions
+sys.stdout = ColorfulStdout(sys.stdout)
+sys.stderr = ColorfulStderr(sys.stderr)
+
+print("✅ Terminal environment configured for colors!")
+      `);
+
       // Load essential packages after Pyodide initialization
       console.log(`📦 Loading essential packages...`);
       try {

--- a/packages/pyodide-runtime-agent/src/pyodide-kernel.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-kernel.ts
@@ -4,6 +4,7 @@
 import { loadPyodide, PyodideInterface } from "pyodide";
 import { OutputType, ErrorOutputData, RichOutputData, StreamOutputData } from "../../../shared/schema.js";
 import { getCacheConfig, getEssentialPackages } from "./cache-utils.js";
+import stripAnsi from "strip-ansi";
 
 export interface OutputData {
   type: OutputType;
@@ -43,11 +44,13 @@ export class PyodideKernel {
         packageCacheDir,
         stdout: (text: string) => {
           console.log("[py stdout]:", text);
-          this.addStreamOutput("stdout", text);
+          // Clean ANSI escape codes at the source for cleaner UI display
+          this.addStreamOutput("stdout", stripAnsi(text));
         },
         stderr: (text: string) => {
           console.error("[py stderr]:", text);
-          this.addStreamOutput("stderr", text);
+          // Clean ANSI escape codes at the source for cleaner UI display
+          this.addStreamOutput("stderr", stripAnsi(text));
         },
       });
 
@@ -244,10 +247,11 @@ shell.displayhook.js_callback = js_execution_callback
       }
 
     } catch (err: unknown) {
+      // Clean ANSI codes from error messages and stack traces
       const errorData: ErrorOutputData = {
-        ename: (err as Error)?.name ?? "KernelError",
-        evalue: (err as Error)?.message ?? "Kernel execution failed",
-        traceback: [(err as Error)?.stack ?? ""],
+        ename: stripAnsi((err as Error)?.name ?? "KernelError"),
+        evalue: stripAnsi((err as Error)?.message ?? "Kernel execution failed"),
+        traceback: [(err as Error)?.stack ?? ""].map(line => stripAnsi(line)),
       };
 
       this.outputs.push({
@@ -311,9 +315,9 @@ shell.displayhook.js_callback = js_execution_callback
     this.outputs.push({
       type: "error",
       data: {
-        ename,
-        evalue,
-        traceback,
+        ename: stripAnsi(ename),
+        evalue: stripAnsi(evalue),
+        traceback: traceback.map(line => stripAnsi(line)),
       } as ErrorOutputData,
       position: this.outputPosition++,
     });

--- a/packages/pyodide-runtime-agent/src/pyodide-kernel.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-kernel.ts
@@ -4,7 +4,6 @@
 import { loadPyodide, PyodideInterface } from "pyodide";
 import { OutputType, ErrorOutputData, RichOutputData, StreamOutputData } from "../../../shared/schema.js";
 import { getCacheConfig, getEssentialPackages } from "./cache-utils.js";
-import stripAnsi from "strip-ansi";
 
 export interface OutputData {
   type: OutputType;
@@ -44,13 +43,11 @@ export class PyodideKernel {
         packageCacheDir,
         stdout: (text: string) => {
           console.log("[py stdout]:", text);
-          // Clean ANSI escape codes at the source for cleaner UI display
-          this.addStreamOutput("stdout", stripAnsi(text));
+          this.addStreamOutput("stdout", text);
         },
         stderr: (text: string) => {
           console.error("[py stderr]:", text);
-          // Clean ANSI escape codes at the source for cleaner UI display
-          this.addStreamOutput("stderr", stripAnsi(text));
+          this.addStreamOutput("stderr", text);
         },
       });
 
@@ -247,11 +244,10 @@ shell.displayhook.js_callback = js_execution_callback
       }
 
     } catch (err: unknown) {
-      // Clean ANSI codes from error messages and stack traces
       const errorData: ErrorOutputData = {
-        ename: stripAnsi((err as Error)?.name ?? "KernelError"),
-        evalue: stripAnsi((err as Error)?.message ?? "Kernel execution failed"),
-        traceback: [(err as Error)?.stack ?? ""].map(line => stripAnsi(line)),
+        ename: (err as Error)?.name ?? "KernelError",
+        evalue: (err as Error)?.message ?? "Kernel execution failed",
+        traceback: [(err as Error)?.stack ?? ""],
       };
 
       this.outputs.push({
@@ -315,9 +311,9 @@ shell.displayhook.js_callback = js_execution_callback
     this.outputs.push({
       type: "error",
       data: {
-        ename: stripAnsi(ename),
-        evalue: stripAnsi(evalue),
-        traceback: traceback.map(line => stripAnsi(line)),
+        ename,
+        evalue,
+        traceback,
       } as ErrorOutputData,
       position: this.outputPosition++,
     });

--- a/packages/pyodide-runtime-agent/src/runtime-agent.ts
+++ b/packages/pyodide-runtime-agent/src/runtime-agent.ts
@@ -20,6 +20,7 @@ import { randomUUID } from "crypto";
 import { events, schema, tables, CellData, ExecutionQueueData, KernelSessionData, OutputData } from "../../../shared/schema.js";
 import { PyodideKernel } from "./pyodide-kernel.js";
 import { openaiClient } from "./openai-client.js";
+import stripAnsi from "strip-ansi";
 
 const NOTEBOOK_ID = process.env.NOTEBOOK_ID ?? "demo-notebook";
 const AUTH_TOKEN = process.env.AUTH_TOKEN ?? "insecure-token-change-me";
@@ -302,26 +303,26 @@ Output:
 `;
         cell.outputs.forEach((output) => {
           if (output.outputType === 'stream') {
-            // Handle stream outputs (stdout/stderr)
+            // Handle stream outputs (stdout/stderr) - clean ANSI for AI consumption
             if (output.data.text) {
               systemPrompt += `\`\`\`
-${output.data.text}
+${stripAnsi(output.data.text)}
 \`\`\`
 `;
             }
           } else if (output.outputType === 'error') {
-            // Handle error outputs
+            // Handle error outputs - clean ANSI for AI consumption
             if (output.data.ename && output.data.evalue) {
               systemPrompt += `\`\`\`
-Error: ${output.data.ename}: ${output.data.evalue}
+Error: ${stripAnsi(output.data.ename)}: ${stripAnsi(output.data.evalue)}
 \`\`\`
 `;
             }
           } else if (output.outputType === 'execute_result' || output.outputType === 'display_data') {
-            // Handle rich outputs
+            // Handle rich outputs - clean ANSI for AI consumption
             if (output.data['text/plain']) {
               systemPrompt += `\`\`\`
-${output.data['text/plain']}
+${stripAnsi(output.data['text/plain'])}
 \`\`\`
 `;
             }

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -31,6 +31,7 @@
     "react-dom": "catalog:",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
+    "strip-ansi": "catalog:",
     "tailwind-merge": "catalog:",
     "tw-animate-css": "catalog:"
   },

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -32,6 +32,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "strip-ansi": "catalog:",
+    "ansi-to-react": "catalog:",
     "tailwind-merge": "catalog:",
     "tw-animate-css": "catalog:"
   },

--- a/packages/web-client/src/components/notebook/AiCell.tsx
+++ b/packages/web-client/src/components/notebook/AiCell.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { RichOutput } from './RichOutput.js'
-import { cleanAnsiCodes, cleanTraceback } from '../../util/ansi-cleaner.js'
+import { AnsiErrorOutput } from './AnsiOutput.js'
 import { Play, ChevronUp, ChevronDown, Plus, X, Bot, Code, FileText, Database, ArrowUp, ArrowDown, Eye, EyeOff } from 'lucide-react'
 
 interface AiCellProps {
@@ -501,23 +501,12 @@ export const AiCell: React.FC<AiCellProps> = ({
             .map((output: OutputData, index: number) => (
               <div key={output.id} className={index > 0 ? "border-t border-border/30 mt-2 pt-2" : ""}>
                 {output.outputType === 'error' ? (
-                  // Keep special error handling for better UX
-                  <div className="py-3 border-l-2 border-red-200 pl-1">
-                    <div className="font-mono text-sm">
-                      <div className="font-semibold text-red-700 mb-1">
-                        {isErrorOutput(output.data)
-                          ? `${cleanAnsiCodes(output.data.ename)}: ${cleanAnsiCodes(output.data.evalue)}`
-                          : 'Unknown error'}
-                      </div>
-                      {isErrorOutput(output.data) && output.data.traceback && (
-                        <div className="mt-2 text-red-600 text-xs whitespace-pre-wrap opacity-80">
-                          {Array.isArray(output.data.traceback)
-                            ? (cleanTraceback(output.data.traceback) as string[]).join('\n')
-                            : cleanTraceback(output.data.traceback) as string}
-                        </div>
-                      )}
-                    </div>
-                  </div>
+                  // Use AnsiErrorOutput for colored error rendering
+                  <AnsiErrorOutput
+                    ename={isErrorOutput(output.data) ? output.data.ename : undefined}
+                    evalue={isErrorOutput(output.data) ? output.data.evalue : undefined}
+                    traceback={isErrorOutput(output.data) ? output.data.traceback : undefined}
+                  />
                 ) : (
                   // Use RichOutput for all other output types
                   <div className="py-2">

--- a/packages/web-client/src/components/notebook/AiCell.tsx
+++ b/packages/web-client/src/components/notebook/AiCell.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { RichOutput } from './RichOutput.js'
+import { cleanAnsiCodes, cleanTraceback } from '../../util/ansi-cleaner.js'
 import { Play, ChevronUp, ChevronDown, Plus, X, Bot, Code, FileText, Database, ArrowUp, ArrowDown, Eye, EyeOff } from 'lucide-react'
 
 interface AiCellProps {
@@ -505,14 +506,14 @@ export const AiCell: React.FC<AiCellProps> = ({
                     <div className="font-mono text-sm">
                       <div className="font-semibold text-red-700 mb-1">
                         {isErrorOutput(output.data)
-                          ? `${output.data.ename}: ${output.data.evalue}`
+                          ? `${cleanAnsiCodes(output.data.ename)}: ${cleanAnsiCodes(output.data.evalue)}`
                           : 'Unknown error'}
                       </div>
                       {isErrorOutput(output.data) && output.data.traceback && (
                         <div className="mt-2 text-red-600 text-xs whitespace-pre-wrap opacity-80">
                           {Array.isArray(output.data.traceback)
-                            ? output.data.traceback.join('\n')
-                            : output.data.traceback}
+                            ? (cleanTraceback(output.data.traceback) as string[]).join('\n')
+                            : cleanTraceback(output.data.traceback) as string}
                         </div>
                       )}
                     </div>

--- a/packages/web-client/src/components/notebook/AnsiOutput.tsx
+++ b/packages/web-client/src/components/notebook/AnsiOutput.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import Ansi from 'ansi-to-react';
+
+interface AnsiOutputProps {
+  children: string;
+  className?: string;
+  isError?: boolean;
+}
+
+/**
+ * AnsiOutput component for rendering ANSI escape sequences as colored text
+ *
+ * This component preserves the beautiful colored output that developers expect
+ * while using ansi-to-react to convert ANSI codes to styled React elements.
+ *
+ * For AI context, use cleanForAI() utility to strip ANSI codes.
+ * For user display, use this component to render the colors.
+ */
+export const AnsiOutput: React.FC<AnsiOutputProps> = ({
+  children,
+  className = '',
+  isError = false
+}) => {
+  if (!children || typeof children !== 'string') {
+    return null;
+  }
+
+  const baseClasses = `font-mono text-sm whitespace-pre-wrap leading-relaxed ${className}`;
+  const errorClasses = isError ? 'text-red-600' : '';
+  const finalClasses = `${baseClasses} ${errorClasses}`.trim();
+
+  return (
+    <div className={finalClasses}>
+      <Ansi useClasses={false}>
+        {children}
+      </Ansi>
+    </div>
+  );
+};
+
+/**
+ * AnsiStreamOutput component specifically for stdout/stderr rendering
+ */
+export const AnsiStreamOutput: React.FC<{
+  text: string;
+  streamName: 'stdout' | 'stderr';
+  className?: string;
+}> = ({ text, streamName, className = '' }) => {
+  const isStderr = streamName === 'stderr';
+  const streamClasses = isStderr ? 'text-red-600' : 'text-gray-700';
+
+  return (
+    <div className={`py-2 ${streamClasses} ${className}`}>
+      <AnsiOutput isError={isStderr}>
+        {text}
+      </AnsiOutput>
+    </div>
+  );
+};
+
+/**
+ * AnsiErrorOutput component specifically for error messages and tracebacks
+ */
+export const AnsiErrorOutput: React.FC<{
+  ename?: string;
+  evalue?: string;
+  traceback?: string[] | string;
+  className?: string;
+}> = ({ ename, evalue, traceback, className = '' }) => {
+  return (
+    <div className={`py-3 border-l-2 border-red-200 pl-1 ${className}`}>
+      {ename && evalue && (
+        <div className="font-semibold text-red-700 mb-1">
+          <AnsiOutput isError>
+            {`${ename}: ${evalue}`}
+          </AnsiOutput>
+        </div>
+      )}
+      {traceback && (
+        <div className="mt-2 text-red-600 text-xs opacity-80">
+          <AnsiOutput isError>
+            {Array.isArray(traceback) ? traceback.join('\n') : traceback}
+          </AnsiOutput>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web-client/src/components/notebook/Cell.tsx
+++ b/packages/web-client/src/components/notebook/Cell.tsx
@@ -16,7 +16,7 @@ import {
 import { SqlCell } from './SqlCell.js'
 import { AiCell } from './AiCell.js'
 import { RichOutput } from './RichOutput'
-import { cleanAnsiCodes, cleanTraceback } from '../../util/ansi-cleaner.js'
+import { AnsiErrorOutput } from './AnsiOutput.js'
 
 import { Play, ChevronUp, ChevronDown, Plus, X, Code, FileText, Database, Bot, ArrowUp, ArrowDown, Eye, EyeOff } from 'lucide-react'
 
@@ -511,23 +511,12 @@ export const Cell: React.FC<CellProps> = ({
               .map((output: OutputData, index: number) => (
                 <div key={output.id} className={index > 0 ? "border-t border-border/30 mt-2 pt-2" : ""}>
                   {output.outputType === 'error' ? (
-                    // Keep special error handling for better UX
-                    <div className="py-3 border-l-2 border-red-200 pl-1">
-                      <div className="font-mono text-sm">
-                        <div className="font-semibold text-red-700 mb-1">
-                          {isErrorOutput(output.data)
-                            ? `${cleanAnsiCodes(output.data.ename)}: ${cleanAnsiCodes(output.data.evalue)}`
-                            : 'Unknown error'}
-                        </div>
-                        {isErrorOutput(output.data) && output.data.traceback && (
-                          <div className="mt-2 text-red-600 text-xs whitespace-pre-wrap opacity-80">
-                            {Array.isArray(output.data.traceback)
-                              ? (cleanTraceback(output.data.traceback) as string[]).join('\n')
-                              : cleanTraceback(output.data.traceback) as string}
-                          </div>
-                        )}
-                      </div>
-                    </div>
+                    // Use AnsiErrorOutput for colored error rendering
+                    <AnsiErrorOutput
+                      ename={isErrorOutput(output.data) ? output.data.ename : undefined}
+                      evalue={isErrorOutput(output.data) ? output.data.evalue : undefined}
+                      traceback={isErrorOutput(output.data) ? output.data.traceback : undefined}
+                    />
                   ) : (
                     // Use RichOutput for all other output types
                     <div className="py-2">

--- a/packages/web-client/src/components/notebook/Cell.tsx
+++ b/packages/web-client/src/components/notebook/Cell.tsx
@@ -15,7 +15,8 @@ import {
 
 import { SqlCell } from './SqlCell.js'
 import { AiCell } from './AiCell.js'
-import { RichOutput } from './RichOutput.js'
+import { RichOutput } from './RichOutput'
+import { cleanAnsiCodes, cleanTraceback } from '../../util/ansi-cleaner.js'
 
 import { Play, ChevronUp, ChevronDown, Plus, X, Code, FileText, Database, Bot, ArrowUp, ArrowDown, Eye, EyeOff } from 'lucide-react'
 
@@ -515,14 +516,14 @@ export const Cell: React.FC<CellProps> = ({
                       <div className="font-mono text-sm">
                         <div className="font-semibold text-red-700 mb-1">
                           {isErrorOutput(output.data)
-                            ? `${output.data.ename}: ${output.data.evalue}`
+                            ? `${cleanAnsiCodes(output.data.ename)}: ${cleanAnsiCodes(output.data.evalue)}`
                             : 'Unknown error'}
                         </div>
                         {isErrorOutput(output.data) && output.data.traceback && (
                           <div className="mt-2 text-red-600 text-xs whitespace-pre-wrap opacity-80">
                             {Array.isArray(output.data.traceback)
-                              ? output.data.traceback.join('\n')
-                              : output.data.traceback}
+                              ? (cleanTraceback(output.data.traceback) as string[]).join('\n')
+                              : cleanTraceback(output.data.traceback) as string}
                           </div>
                         )}
                       </div>

--- a/packages/web-client/src/components/notebook/RichOutput.tsx
+++ b/packages/web-client/src/components/notebook/RichOutput.tsx
@@ -4,7 +4,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { StreamOutputData } from '../../../../../shared/schema.js'
 import { FilePlus, Edit, ChevronDown, Info } from 'lucide-react'
-import { cleanStreamOutput } from '../../util/ansi-cleaner.js'
+import { AnsiStreamOutput } from './AnsiOutput.js'
 import './RichOutput.css'
 
 interface RichOutputProps {
@@ -71,14 +71,12 @@ export const RichOutput: React.FC<RichOutputProps> = ({
   // Handle stream outputs specially
   if (outputType === 'stream') {
     const streamData = data as unknown as StreamOutputData
-    const isStderr = streamData.name === 'stderr'
 
     return (
-      <div className={`py-2 ${isStderr ? 'text-red-600' : 'text-gray-700'}`}>
-        <div className="font-mono text-sm whitespace-pre-wrap leading-relaxed">
-          {cleanStreamOutput(streamData.text)}
-        </div>
-      </div>
+      <AnsiStreamOutput
+        text={streamData.text}
+        streamName={streamData.name}
+      />
     )
   }
 

--- a/packages/web-client/src/components/notebook/RichOutput.tsx
+++ b/packages/web-client/src/components/notebook/RichOutput.tsx
@@ -4,6 +4,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { StreamOutputData } from '../../../../../shared/schema.js'
 import { FilePlus, Edit, ChevronDown, Info } from 'lucide-react'
+import { cleanStreamOutput } from '../../util/ansi-cleaner.js'
 import './RichOutput.css'
 
 interface RichOutputProps {
@@ -75,7 +76,7 @@ export const RichOutput: React.FC<RichOutputProps> = ({
     return (
       <div className={`py-2 ${isStderr ? 'text-red-600' : 'text-gray-700'}`}>
         <div className="font-mono text-sm whitespace-pre-wrap leading-relaxed">
-          {streamData.text}
+          {cleanStreamOutput(streamData.text)}
         </div>
       </div>
     )

--- a/packages/web-client/src/util/ansi-cleaner.test.ts
+++ b/packages/web-client/src/util/ansi-cleaner.test.ts
@@ -1,52 +1,52 @@
 import { describe, it, expect } from 'vitest';
-import { cleanAnsiCodes, cleanTraceback, cleanStreamOutput } from './ansi-cleaner.js';
+import { cleanForAI, cleanTracebackForAI, cleanAnsiCodes, cleanTraceback, cleanStreamOutput } from './ansi-cleaner.js';
 
 describe('ANSI Cleaner Utilities', () => {
-  describe('cleanAnsiCodes', () => {
-    it('should remove ANSI color codes', () => {
+  describe('cleanForAI', () => {
+    it('should remove ANSI color codes for AI context', () => {
       const input = '\u001b[31mThis is red text\u001b[0m';
       const expected = 'This is red text';
-      expect(cleanAnsiCodes(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
 
-    it('should remove complex ANSI sequences', () => {
+    it('should remove complex ANSI sequences for AI context', () => {
       const input = '\u001b[0;31mAttributeError\u001b[0m                            \u001b[0mTraceback (most recent call last)\u001b[0m';
       const expected = 'AttributeError                            Traceback (most recent call last)';
-      expect(cleanAnsiCodes(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
 
-    it('should handle hyperlink ANSI sequences', () => {
+    it('should handle hyperlink ANSI sequences for AI context', () => {
       const input = '\u001b]8;;https://example.com\u0007Link Text\u001b]8;;\u0007';
       const expected = 'Link Text';
-      expect(cleanAnsiCodes(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
 
-    it('should handle cursor movement codes', () => {
+    it('should handle cursor movement codes for AI context', () => {
       const input = '\u001b[2J\u001b[H\u001b[3;1HHello World';
       const expected = 'Hello World';
-      expect(cleanAnsiCodes(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
 
-    it('should preserve text without ANSI codes', () => {
+    it('should preserve text without ANSI codes for AI context', () => {
       const input = 'This is plain text';
-      expect(cleanAnsiCodes(input)).toBe(input);
+      expect(cleanForAI(input)).toBe(input);
     });
 
-    it('should handle empty or null input', () => {
-      expect(cleanAnsiCodes('')).toBe('');
-      expect(cleanAnsiCodes(null as any)).toBe(null);
-      expect(cleanAnsiCodes(undefined as any)).toBe(undefined);
+    it('should handle empty or null input for AI context', () => {
+      expect(cleanForAI('')).toBe('');
+      expect(cleanForAI(null as any)).toBe(null);
+      expect(cleanForAI(undefined as any)).toBe(undefined);
     });
 
-    it('should handle mixed content with multiple ANSI sequences', () => {
+    it('should handle mixed content with multiple ANSI sequences for AI context', () => {
       const input = '\u001b[1;32mSuccess:\u001b[0m Operation completed \u001b[31mwith warnings\u001b[0m';
       const expected = 'Success: Operation completed with warnings';
-      expect(cleanAnsiCodes(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
   });
 
-  describe('cleanTraceback', () => {
-    it('should clean ANSI codes from traceback array', () => {
+  describe('cleanTracebackForAI', () => {
+    it('should clean ANSI codes from traceback array for AI context', () => {
       const input = [
         '\u001b[31mTraceback (most recent call last):\u001b[0m',
         '  File "<stdin>", line 1, in <module>',
@@ -57,24 +57,24 @@ describe('ANSI Cleaner Utilities', () => {
         '  File "<stdin>", line 1, in <module>',
         'AttributeError: \'str\' object has no attribute \'nonexistent\'',
       ];
-      expect(cleanTraceback(input)).toEqual(expected);
+      expect(cleanTracebackForAI(input)).toEqual(expected);
     });
 
-    it('should clean ANSI codes from traceback string', () => {
+    it('should clean ANSI codes from traceback string for AI context', () => {
       const input = '\u001b[31mError:\u001b[0m Something went wrong';
       const expected = 'Error: Something went wrong';
-      expect(cleanTraceback(input)).toBe(expected);
+      expect(cleanTracebackForAI(input)).toBe(expected);
     });
 
-    it('should handle undefined traceback', () => {
-      expect(cleanTraceback(undefined)).toBe(undefined);
+    it('should handle undefined traceback for AI context', () => {
+      expect(cleanTracebackForAI(undefined)).toBe(undefined);
     });
 
-    it('should handle empty traceback array', () => {
-      expect(cleanTraceback([])).toEqual([]);
+    it('should handle empty traceback array for AI context', () => {
+      expect(cleanTracebackForAI([])).toEqual([]);
     });
 
-    it('should handle Python-style colored traceback', () => {
+    it('should handle Python-style colored traceback for AI context', () => {
       const input = [
         '\u001b[0;32mIn [1]: \u001b[0m\u001b[0;34mprint\u001b[0m\u001b[0;37m(\u001b[0m\u001b[0;31m"hello"\u001b[0m\u001b[0;37m.\u001b[0m\u001b[0;32mnonexistent\u001b[0m\u001b[0;37m(\u001b[0m\u001b[0;37m)\u001b[0m\u001b[0;37m)\u001b[0m',
         '\u001b[0;31m---------------------------------------------------------------------------\u001b[0m',
@@ -85,55 +85,58 @@ describe('ANSI Cleaner Utilities', () => {
         '---------------------------------------------------------------------------',
         'AttributeError                            Traceback (most recent call last)',
       ];
-      expect(cleanTraceback(input)).toEqual(expected);
+      expect(cleanTracebackForAI(input)).toEqual(expected);
     });
   });
 
-  describe('cleanStreamOutput', () => {
-    it('should clean ANSI codes from stream output', () => {
+  describe('Legacy compatibility functions', () => {
+    it('cleanAnsiCodes should work as alias to cleanForAI', () => {
+      const input = '\u001b[31mThis is red text\u001b[0m';
+      const expected = 'This is red text';
+      expect(cleanAnsiCodes(input)).toBe(expected);
+      expect(cleanAnsiCodes(input)).toBe(cleanForAI(input));
+    });
+
+    it('cleanTraceback should work as alias to cleanTracebackForAI', () => {
+      const input = ['\u001b[31mError\u001b[0m'];
+      const expected = ['Error'];
+      expect(cleanTraceback(input)).toEqual(expected);
+      expect(cleanTraceback(input)).toEqual(cleanTracebackForAI(input));
+    });
+
+    it('cleanStreamOutput should work as alias to cleanForAI', () => {
       const input = '\u001b[32mProcessing...\u001b[0m\n\u001b[31mError occurred!\u001b[0m';
       const expected = 'Processing...\nError occurred!';
       expect(cleanStreamOutput(input)).toBe(expected);
-    });
-
-    it('should handle progress indicators with ANSI codes', () => {
-      const input = '\u001b[2K\u001b[1GProgress: \u001b[32m████████████\u001b[0m 100%';
-      const expected = 'Progress: ████████████ 100%';
-      expect(cleanStreamOutput(input)).toBe(expected);
-    });
-
-    it('should preserve whitespace and newlines', () => {
-      const input = '\u001b[31mLine 1\u001b[0m\n  \u001b[32mIndented line 2\u001b[0m\n\n\u001b[33mLine 4 after blank\u001b[0m';
-      const expected = 'Line 1\n  Indented line 2\n\nLine 4 after blank';
-      expect(cleanStreamOutput(input)).toBe(expected);
+      expect(cleanStreamOutput(input)).toBe(cleanForAI(input));
     });
   });
 
-  describe('Real-world examples', () => {
-    it('should handle GeoPandas error from screenshot', () => {
+  describe('Real-world examples for AI context', () => {
+    it('should clean GeoPandas error for AI consumption while preserving structure', () => {
       // This simulates the kind of error shown in the user's screenshot
       const input = '\u001b[0;31mAttributeError\u001b[0m                            \u001b[0mTraceback (most recent call last)\u001b[0m\n\u001b[0;32mIn [1]\u001b[0m, line \u001b[0;36m6\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;66;03m# Load a sample GeoDataFrame\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m# Display the first few rows of the GeoDataFrame\u001b[39;00m\n\u001b[0;32m----> 6\u001b[0m world \u001b[38;5;241m=\u001b[39m \u001b[43mgpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_file\u001b[49m\u001b[43m(\u001b[49m\u001b[43mgpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdatasets\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_path\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\'\u001b[39;49m\u001b[38;5;124;43mnaturalearth_lowres\u001b[39;49m\u001b[38;5;124;43m\'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m';
 
-      const cleaned = cleanAnsiCodes(input);
+      const cleaned = cleanForAI(input);
 
-      // Should not contain any ANSI escape sequences
+      // Should not contain any ANSI escape sequences for AI parsing
       expect(cleaned).not.toMatch(/\u001b/);
-      // Should contain readable error information
+      // Should contain readable error information for AI understanding
       expect(cleaned).toContain('AttributeError');
       expect(cleaned).toContain('Traceback (most recent call last)');
       expect(cleaned).toContain('naturalearth_lowres');
     });
 
-    it('should handle progress bars and loading indicators', () => {
+    it('should clean progress bars for AI context while preserving content', () => {
       const input = '\u001b[2K\u001b[1G\u001b[32m████████████████████\u001b[0m \u001b[1m100%\u001b[0m Loading packages...';
       const expected = '████████████████████ 100% Loading packages...';
-      expect(cleanStreamOutput(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
 
-    it('should handle IPython-style colored output', () => {
+    it('should clean IPython-style output for AI context', () => {
       const input = '\u001b[0;31mOut[\u001b[1;32m1\u001b[0;31m]:\u001b[0m \u001b[0;35m42\u001b[0m';
       const expected = 'Out[1]: 42';
-      expect(cleanStreamOutput(input)).toBe(expected);
+      expect(cleanForAI(input)).toBe(expected);
     });
   });
 });

--- a/packages/web-client/src/util/ansi-cleaner.test.ts
+++ b/packages/web-client/src/util/ansi-cleaner.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { cleanAnsiCodes, cleanTraceback, cleanStreamOutput } from './ansi-cleaner.js';
+
+describe('ANSI Cleaner Utilities', () => {
+  describe('cleanAnsiCodes', () => {
+    it('should remove ANSI color codes', () => {
+      const input = '\u001b[31mThis is red text\u001b[0m';
+      const expected = 'This is red text';
+      expect(cleanAnsiCodes(input)).toBe(expected);
+    });
+
+    it('should remove complex ANSI sequences', () => {
+      const input = '\u001b[0;31mAttributeError\u001b[0m                            \u001b[0mTraceback (most recent call last)\u001b[0m';
+      const expected = 'AttributeError                            Traceback (most recent call last)';
+      expect(cleanAnsiCodes(input)).toBe(expected);
+    });
+
+    it('should handle hyperlink ANSI sequences', () => {
+      const input = '\u001b]8;;https://example.com\u0007Link Text\u001b]8;;\u0007';
+      const expected = 'Link Text';
+      expect(cleanAnsiCodes(input)).toBe(expected);
+    });
+
+    it('should handle cursor movement codes', () => {
+      const input = '\u001b[2J\u001b[H\u001b[3;1HHello World';
+      const expected = 'Hello World';
+      expect(cleanAnsiCodes(input)).toBe(expected);
+    });
+
+    it('should preserve text without ANSI codes', () => {
+      const input = 'This is plain text';
+      expect(cleanAnsiCodes(input)).toBe(input);
+    });
+
+    it('should handle empty or null input', () => {
+      expect(cleanAnsiCodes('')).toBe('');
+      expect(cleanAnsiCodes(null as any)).toBe(null);
+      expect(cleanAnsiCodes(undefined as any)).toBe(undefined);
+    });
+
+    it('should handle mixed content with multiple ANSI sequences', () => {
+      const input = '\u001b[1;32mSuccess:\u001b[0m Operation completed \u001b[31mwith warnings\u001b[0m';
+      const expected = 'Success: Operation completed with warnings';
+      expect(cleanAnsiCodes(input)).toBe(expected);
+    });
+  });
+
+  describe('cleanTraceback', () => {
+    it('should clean ANSI codes from traceback array', () => {
+      const input = [
+        '\u001b[31mTraceback (most recent call last):\u001b[0m',
+        '  File "<stdin>", line 1, in <module>',
+        '\u001b[38;5;241mAttributeError\u001b[0m: \'str\' object has no attribute \'nonexistent\'',
+      ];
+      const expected = [
+        'Traceback (most recent call last):',
+        '  File "<stdin>", line 1, in <module>',
+        'AttributeError: \'str\' object has no attribute \'nonexistent\'',
+      ];
+      expect(cleanTraceback(input)).toEqual(expected);
+    });
+
+    it('should clean ANSI codes from traceback string', () => {
+      const input = '\u001b[31mError:\u001b[0m Something went wrong';
+      const expected = 'Error: Something went wrong';
+      expect(cleanTraceback(input)).toBe(expected);
+    });
+
+    it('should handle undefined traceback', () => {
+      expect(cleanTraceback(undefined)).toBe(undefined);
+    });
+
+    it('should handle empty traceback array', () => {
+      expect(cleanTraceback([])).toEqual([]);
+    });
+
+    it('should handle Python-style colored traceback', () => {
+      const input = [
+        '\u001b[0;32mIn [1]: \u001b[0m\u001b[0;34mprint\u001b[0m\u001b[0;37m(\u001b[0m\u001b[0;31m"hello"\u001b[0m\u001b[0;37m.\u001b[0m\u001b[0;32mnonexistent\u001b[0m\u001b[0;37m(\u001b[0m\u001b[0;37m)\u001b[0m\u001b[0;37m)\u001b[0m',
+        '\u001b[0;31m---------------------------------------------------------------------------\u001b[0m',
+        '\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)',
+      ];
+      const expected = [
+        'In [1]: print("hello".nonexistent())',
+        '---------------------------------------------------------------------------',
+        'AttributeError                            Traceback (most recent call last)',
+      ];
+      expect(cleanTraceback(input)).toEqual(expected);
+    });
+  });
+
+  describe('cleanStreamOutput', () => {
+    it('should clean ANSI codes from stream output', () => {
+      const input = '\u001b[32mProcessing...\u001b[0m\n\u001b[31mError occurred!\u001b[0m';
+      const expected = 'Processing...\nError occurred!';
+      expect(cleanStreamOutput(input)).toBe(expected);
+    });
+
+    it('should handle progress indicators with ANSI codes', () => {
+      const input = '\u001b[2K\u001b[1GProgress: \u001b[32m████████████\u001b[0m 100%';
+      const expected = 'Progress: ████████████ 100%';
+      expect(cleanStreamOutput(input)).toBe(expected);
+    });
+
+    it('should preserve whitespace and newlines', () => {
+      const input = '\u001b[31mLine 1\u001b[0m\n  \u001b[32mIndented line 2\u001b[0m\n\n\u001b[33mLine 4 after blank\u001b[0m';
+      const expected = 'Line 1\n  Indented line 2\n\nLine 4 after blank';
+      expect(cleanStreamOutput(input)).toBe(expected);
+    });
+  });
+
+  describe('Real-world examples', () => {
+    it('should handle GeoPandas error from screenshot', () => {
+      // This simulates the kind of error shown in the user's screenshot
+      const input = '\u001b[0;31mAttributeError\u001b[0m                            \u001b[0mTraceback (most recent call last)\u001b[0m\n\u001b[0;32mIn [1]\u001b[0m, line \u001b[0;36m6\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;66;03m# Load a sample GeoDataFrame\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m# Display the first few rows of the GeoDataFrame\u001b[39;00m\n\u001b[0;32m----> 6\u001b[0m world \u001b[38;5;241m=\u001b[39m \u001b[43mgpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_file\u001b[49m\u001b[43m(\u001b[49m\u001b[43mgpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdatasets\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_path\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\'\u001b[39;49m\u001b[38;5;124;43mnaturalearth_lowres\u001b[39;49m\u001b[38;5;124;43m\'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m';
+
+      const cleaned = cleanAnsiCodes(input);
+
+      // Should not contain any ANSI escape sequences
+      expect(cleaned).not.toMatch(/\u001b/);
+      // Should contain readable error information
+      expect(cleaned).toContain('AttributeError');
+      expect(cleaned).toContain('Traceback (most recent call last)');
+      expect(cleaned).toContain('naturalearth_lowres');
+    });
+
+    it('should handle progress bars and loading indicators', () => {
+      const input = '\u001b[2K\u001b[1G\u001b[32m████████████████████\u001b[0m \u001b[1m100%\u001b[0m Loading packages...';
+      const expected = '████████████████████ 100% Loading packages...';
+      expect(cleanStreamOutput(input)).toBe(expected);
+    });
+
+    it('should handle IPython-style colored output', () => {
+      const input = '\u001b[0;31mOut[\u001b[1;32m1\u001b[0;31m]:\u001b[0m \u001b[0;35m42\u001b[0m';
+      const expected = 'Out[1]: 42';
+      expect(cleanStreamOutput(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/web-client/src/util/ansi-cleaner.ts
+++ b/packages/web-client/src/util/ansi-cleaner.ts
@@ -1,0 +1,52 @@
+import stripAnsi from 'strip-ansi';
+
+/**
+ * Cleans ANSI escape codes from text output for display
+ *
+ * This utility handles the messy terminal output that comes from Python execution,
+ * stripping color codes, cursor movement, and other ANSI sequences to provide
+ * clean, readable text for the UI.
+ *
+ * @param text - Raw text that may contain ANSI escape sequences
+ * @returns Clean text with ANSI codes removed
+ */
+export function cleanAnsiCodes(text: string): string {
+  if (!text || typeof text !== 'string') {
+    return text;
+  }
+
+  return stripAnsi(text);
+}
+
+/**
+ * Cleans ANSI codes from error traceback arrays
+ *
+ * Python tracebacks often contain ANSI color codes that make them hard to read
+ * in a web interface. This function cleans each line of the traceback.
+ *
+ * @param traceback - Array of traceback lines or single string
+ * @returns Cleaned traceback
+ */
+export function cleanTraceback(traceback: string[] | string | undefined): string[] | string | undefined {
+  if (!traceback) {
+    return traceback;
+  }
+
+  if (Array.isArray(traceback)) {
+    return traceback.map(line => cleanAnsiCodes(line));
+  }
+
+  return cleanAnsiCodes(traceback);
+}
+
+/**
+ * Cleans ANSI codes from stream output data
+ *
+ * This handles stdout/stderr output that may contain terminal formatting
+ *
+ * @param text - Stream text that may contain ANSI codes
+ * @returns Clean stream text
+ */
+export function cleanStreamOutput(text: string): string {
+  return cleanAnsiCodes(text);
+}

--- a/packages/web-client/src/util/ansi-cleaner.ts
+++ b/packages/web-client/src/util/ansi-cleaner.ts
@@ -1,16 +1,16 @@
 import stripAnsi from 'strip-ansi';
 
 /**
- * Cleans ANSI escape codes from text output for display
+ * Cleans ANSI escape codes from text for AI context consumption
  *
- * This utility handles the messy terminal output that comes from Python execution,
- * stripping color codes, cursor movement, and other ANSI sequences to provide
- * clean, readable text for the UI.
+ * This utility strips ANSI codes to provide clean, readable text that
+ * AI models can properly parse and understand. The original ANSI codes
+ * are preserved in the raw data for user display rendering.
  *
  * @param text - Raw text that may contain ANSI escape sequences
- * @returns Clean text with ANSI codes removed
+ * @returns Clean text with ANSI codes removed for AI processing
  */
-export function cleanAnsiCodes(text: string): string {
+export function cleanForAI(text: string): string {
   if (!text || typeof text !== 'string') {
     return text;
   }
@@ -19,34 +19,46 @@ export function cleanAnsiCodes(text: string): string {
 }
 
 /**
- * Cleans ANSI codes from error traceback arrays
+ * Cleans ANSI codes from error traceback for AI context
  *
- * Python tracebacks often contain ANSI color codes that make them hard to read
- * in a web interface. This function cleans each line of the traceback.
+ * Python tracebacks often contain ANSI color codes that interfere with
+ * AI model understanding. This strips codes while preserving structure.
  *
  * @param traceback - Array of traceback lines or single string
- * @returns Cleaned traceback
+ * @returns Cleaned traceback for AI consumption
  */
-export function cleanTraceback(traceback: string[] | string | undefined): string[] | string | undefined {
+export function cleanTracebackForAI(traceback: string[] | string | undefined): string[] | string | undefined {
   if (!traceback) {
     return traceback;
   }
 
   if (Array.isArray(traceback)) {
-    return traceback.map(line => cleanAnsiCodes(line));
+    return traceback.map(line => cleanForAI(line));
   }
 
-  return cleanAnsiCodes(traceback);
+  return cleanForAI(traceback);
 }
 
 /**
- * Cleans ANSI codes from stream output data
- *
- * This handles stdout/stderr output that may contain terminal formatting
- *
- * @param text - Stream text that may contain ANSI codes
- * @returns Clean stream text
+ * Legacy function - use cleanForAI instead
+ * @deprecated Use cleanForAI for AI context or preserve ANSI for user display
+ */
+export function cleanAnsiCodes(text: string): string {
+  return cleanForAI(text);
+}
+
+/**
+ * Legacy function - use cleanTracebackForAI instead
+ * @deprecated Use cleanTracebackForAI for AI context or preserve ANSI for user display
+ */
+export function cleanTraceback(traceback: string[] | string | undefined): string[] | string | undefined {
+  return cleanTracebackForAI(traceback);
+}
+
+/**
+ * Legacy function - use cleanForAI instead
+ * @deprecated Use cleanForAI for AI context or preserve ANSI for user display
  */
 export function cleanStreamOutput(text: string): string {
-  return cleanAnsiCodes(text);
+  return cleanForAI(text);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     '@vitest/ui':
       specifier: ^3.0.0
       version: 3.2.3
+    ansi-to-react:
+      specifier: ^6.1.6
+      version: 6.1.6
     autoprefixer:
       specifier: ^10.4.21
       version: 10.4.21
@@ -265,6 +268,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      ansi-to-react:
+        specifier: 'catalog:'
+        version: 6.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
@@ -1888,6 +1894,9 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  anser@1.4.10:
+    resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1899,6 +1908,12 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-to-react@6.1.6:
+    resolution: {integrity: sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==}
+    peerDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
@@ -2138,6 +2153,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-carriage@1.3.1:
+    resolution: {integrity: sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==}
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
@@ -4844,6 +4862,8 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  anser@1.4.10: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -4851,6 +4871,13 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-to-react@6.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      anser: 1.4.10
+      escape-carriage: 1.3.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   aria-hidden@1.2.6:
     dependencies:
@@ -5109,6 +5136,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.5
 
   escalade@3.2.0: {}
+
+  escape-carriage@1.3.1: {}
 
   estree-util-is-identifier-name@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ catalogs:
     pyodide:
       specifier: ^0.27.7
       version: 0.27.7
+    strip-ansi:
+      specifier: ^7.1.0
+      version: 7.1.0
     tailwind-merge:
       specifier: ^3.3.1
       version: 3.3.1
@@ -201,6 +204,9 @@ importers:
       pyodide:
         specifier: 'catalog:'
         version: 0.27.7
+      strip-ansi:
+        specifier: 'catalog:'
+        version: 7.1.0
     devDependencies:
       '@effect/vitest':
         specifier: 'catalog:'
@@ -283,6 +289,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.1(react@19.0.0)
+      strip-ansi:
+        specifier: 'catalog:'
+        version: 7.1.0
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.3.1
@@ -1883,6 +1892,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -2891,6 +2904,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
@@ -4829,6 +4846,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.1.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -5992,6 +6011,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
 
   strip-literal@3.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,3 +58,4 @@ catalog:
   concurrently: ^9.1.2
   "@overengineering/fps-meter": 0.1.2
   strip-ansi: ^7.1.0
+  ansi-to-react: ^6.1.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,3 +57,4 @@ catalog:
   "@cloudflare/workers-types": ^4.20250106.0
   concurrently: ^9.1.2
   "@overengineering/fps-meter": 0.1.2
+  strip-ansi: ^7.1.0

--- a/test-rich-output.py
+++ b/test-rich-output.py
@@ -1,0 +1,178 @@
+# Rich Library Test Examples for ANSI Output Rendering
+# This file contains various rich library examples to test our new ANSI-to-React rendering
+
+from rich.console import Console
+from rich.text import Text
+from rich.panel import Panel
+from rich.table import Table
+from rich.progress import Progress, BarColumn, TextColumn
+from rich.syntax import Syntax
+from rich.tree import Tree
+from rich.columns import Columns
+from rich.align import Align
+from rich import print as rprint
+import time
+
+console = Console()
+
+print("🎨 Testing Rich Library ANSI Output Rendering")
+print("=" * 50)
+
+# Test 1: Basic colored text
+console.print("✨ Test 1: Basic Rich Colors", style="bold blue")
+console.print("This is [red]red text[/red]")
+console.print("This is [green]green text[/green]")
+console.print("This is [yellow]yellow text[/yellow]")
+console.print("This is [blue]blue text[/blue]")
+console.print("This is [magenta]magenta text[/magenta]")
+console.print("This is [cyan]cyan text[/cyan]")
+console.print("")
+
+# Test 2: Mixed styling
+console.print("✨ Test 2: Mixed Styling", style="bold blue")
+console.print("This is [bold red]bold red[/bold red] text")
+console.print("This is [italic green]italic green[/italic green] text")
+console.print("This is [underline yellow]underlined yellow[/underline yellow] text")
+console.print(
+    "Mix [bold cyan]bold cyan[/bold cyan] with [dim white]dim white[/dim white]"
+)
+console.print("")
+
+# Test 3: Text objects with multiple styles
+console.print("✨ Test 3: Text Objects", style="bold blue")
+text = Text("Hello, World!")
+text.stylize("bold red", 0, 6)  # "Hello,"
+text.stylize("italic blue", 7, 13)  # "World!"
+console.print(text)
+
+# Create rainbow text
+rainbow_text = Text("Rainbow Colors!")
+colors = ["red", "yellow", "green", "cyan", "blue", "magenta"]
+for i, char in enumerate("Rainbow Colors!"):
+    if char != " ":
+        rainbow_text.stylize(colors[i % len(colors)], i, i + 1)
+console.print(rainbow_text)
+console.print("")
+
+# Test 4: Panels and boxes
+console.print("✨ Test 4: Panels and Boxes", style="bold blue")
+console.print(Panel("This is a [red]red panel[/red] with borders", title="Info"))
+console.print(
+    Panel("This is a [green]success panel[/green]", title="✓ Success", style="green")
+)
+console.print(
+    Panel("This is a [yellow]warning panel[/yellow]", title="⚠ Warning", style="yellow")
+)
+console.print(Panel("This is an [red]error panel[/red]", title="❌ Error", style="red"))
+console.print("")
+
+# Test 5: Tables
+console.print("✨ Test 5: Colored Tables", style="bold blue")
+table = Table(title="Sample Data")
+table.add_column("Name", style="cyan", no_wrap=True)
+table.add_column("Age", style="magenta", justify="right")
+table.add_column("Status", style="green")
+
+table.add_row("Alice", "25", "Active")
+table.add_row("Bob", "30", "Inactive")
+table.add_row("Charlie", "35", "Active")
+
+console.print(table)
+console.print("")
+
+# Test 6: Progress bars
+console.print("✨ Test 6: Progress Bars", style="bold blue")
+with Progress(
+    TextColumn("[progress.description]{task.description}"),
+    BarColumn(),
+    TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+) as progress:
+    task = progress.add_task("Processing...", total=100)
+    for i in range(100):
+        progress.update(task, advance=1)
+        time.sleep(0.01)  # Small delay to see animation
+
+console.print("✅ Progress complete!")
+console.print("")
+
+# Test 7: Syntax highlighting
+console.print("✨ Test 7: Syntax Highlighting", style="bold blue")
+code = '''
+def fibonacci(n):
+    """Calculate fibonacci number recursively."""
+    if n <= 1:
+        return n
+    return fibonacci(n-1) + fibonacci(n-2)
+
+# Test the function
+result = fibonacci(10)
+print(f"Fibonacci(10) = {result}")
+'''
+
+syntax = Syntax(code, "python", theme="monokai", line_numbers=True)
+console.print(syntax)
+console.print("")
+
+# Test 8: Tree structure
+console.print("✨ Test 8: Tree Structure", style="bold blue")
+tree = Tree("🌳 Project Structure")
+tree.add("📁 src/")
+tree.add("📁 tests/")
+docs = tree.add("📁 docs/")
+docs.add("📄 README.md")
+docs.add("📄 API.md")
+src = tree.add("📁 components/")
+src.add("⚛️ Button.tsx")
+src.add("⚛️ Modal.tsx")
+
+console.print(tree)
+console.print("")
+
+# Test 9: Columns layout
+console.print("✨ Test 9: Column Layout", style="bold blue")
+console.print(
+    Columns(
+        [
+            Panel("Column 1\n[red]Red content[/red]", style="blue"),
+            Panel("Column 2\n[green]Green content[/green]", style="green"),
+            Panel("Column 3\n[yellow]Yellow content[/yellow]", style="yellow"),
+        ]
+    )
+)
+console.print("")
+
+# Test 10: Rich print function
+console.print("✨ Test 10: Rich Print Function", style="bold blue")
+rprint("Using [bold blue]rprint()[/bold blue] for easy markup!")
+rprint({"key": "value", "number": 42, "list": [1, 2, 3]})
+rprint(["apple", "banana", "cherry"])
+console.print("")
+
+# Test 11: Status messages
+console.print("✨ Test 11: Status Messages", style="bold blue")
+console.print("✅ [green]Success:[/green] Operation completed successfully")
+console.print("⚠️  [yellow]Warning:[/yellow] This is a warning message")
+console.print("❌ [red]Error:[/red] Something went wrong")
+console.print("ℹ️  [blue]Info:[/blue] Here's some information")
+console.print("🔄 [cyan]Processing:[/cyan] Working on it...")
+console.print("")
+
+# Test 12: Emoji and Unicode
+console.print("✨ Test 12: Emoji and Unicode", style="bold blue")
+console.print("🎉 [rainbow]Celebration[/rainbow] time!")
+console.print("🚀 [bold green]Launch successful![/bold green]")
+console.print("💡 [yellow]Bright idea:[/yellow] Use more colors!")
+console.print("⭐ [gold1]Five star rating[/gold1] ⭐⭐⭐⭐⭐")
+console.print("")
+
+# Final message
+console.print(
+    Panel.fit(
+        "[bold green]🎊 Rich ANSI Test Complete! 🎊[/bold green]\n"
+        "[dim]All colors should render beautifully with your ansi-to-react setup![/dim]",
+        style="green",
+    )
+)
+
+print("\n" + "=" * 50)
+print("🏁 Test file execution complete!")

--- a/test-terminal-detection.py
+++ b/test-terminal-detection.py
@@ -1,0 +1,57 @@
+# Terminal Detection Test
+# This tests whether our Pyodide environment is properly configured to report as a terminal
+
+import sys
+import os
+
+print("🔍 Terminal Detection Test")
+print("=" * 40)
+
+# Test 1: Check if stdout/stderr report as TTY
+print(f"📺 sys.stdout.isatty(): {sys.stdout.isatty()}")
+print(f"📺 sys.stderr.isatty(): {sys.stderr.isatty()}")
+
+# Test 2: Check environment variables
+print("\n🌍 Environment Variables:")
+terminal_vars = ["TERM", "FORCE_COLOR", "COLORTERM", "CLICOLOR", "CLICOLOR_FORCE"]
+for var in terminal_vars:
+    value = os.environ.get(var, "NOT SET")
+    print(f"   {var}: {value}")
+
+# Test 3: Test rich detection
+print("\n🎨 Rich Library Detection:")
+try:
+    from rich.console import Console
+
+    # Create console without forcing terminal
+    console = Console()
+
+    print(f"   Rich detects terminal: {console.is_terminal}")
+    print(f"   Rich color system: {console.color_system}")
+    print(f"   Rich size: {console.size}")
+
+    # Test actual colored output
+    print("\n✨ Rich Color Test:")
+    console.print("   This should be [red]RED[/red]!")
+    console.print("   This should be [green]GREEN[/green]!")
+    console.print("   This should be [blue]BLUE[/blue]!")
+    console.print("   This should be [bold yellow]BOLD YELLOW[/bold yellow]!")
+
+except ImportError:
+    print("   Rich not available - that's okay for basic testing")
+
+# Test 4: Test basic ANSI codes
+print("\n🌈 Basic ANSI Color Test:")
+print("   \033[31mThis should be RED\033[0m")
+print("   \033[32mThis should be GREEN\033[0m")
+print("   \033[34mThis should be BLUE\033[0m")
+print("   \033[1;33mThis should be BOLD YELLOW\033[0m")
+
+print("\n" + "=" * 40)
+print("🏁 Terminal detection test complete!")
+
+# Expected results:
+# - isatty() should return True
+# - Environment variables should be set
+# - Rich should detect terminal and use colors
+# - ANSI codes should be preserved in output


### PR DESCRIPTION
Python execution in Anode was producing messy ANSI escape codes in error outputs, making them hard to read. Additionally, libraries like `rich` weren't producing colored output because Pyodide doesn't report as a proper terminal environment.

**Before:**
```
[0;31mAttributeError  [0m[39m[0mTraceback (most recent call last)
```

**After:**

![image](https://github.com/user-attachments/assets/2d00339f-441e-41cf-b892-a7cefb7cb14e)

- 🤖 **AI models**: Get clean, parseable text without escape codes
- 👨‍💻 **Users**: See beautiful colored terminal output as intended

### 🏗️ **Dual-Mode Architecture**
1. **Raw ANSI preserved** in LiveStore events for authentic terminal experience
2. **AI context cleaning** strips ANSI codes when building model prompts
3. **User display rendering** converts ANSI to beautiful React components

### 🎨 **Terminal Environment Configuration**
- Configure Pyodide to report as proper terminal (`xterm-256color`)
- Mock `sys.stdout.isatty()` to return `True` for color detection
- Set environment variables (`FORCE_COLOR`, `COLORTERM`, etc.)
- Enable automatic color support for **all** Python libraries


