### PR TITLE
Fix/cloudflare worker auth deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ pyodide-cache/
 
 # LiveStore tmp directories
 tmp/
+
+# Local network configuration
+Caddyfile

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,22 @@
+# Simple Caddyfile for local network HTTPS access
+# Binds directly to your local IP address
+#
+# Usage:
+# 1. Copy this file to 'Caddyfile' (without .example extension)
+# 2. Replace 192.168.1.100 with your actual local IP address
+# 3. Run: pnpm dev:caddy
+
+192.168.1.100:8443 {
+	# Proxy to your Vite dev server
+	reverse_proxy localhost:5173
+
+	# Use internal CA for self-signed certificate
+	tls internal
+
+	# Enable CORS for local development
+	header {
+		Access-Control-Allow-Origin *
+		Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+		Access-Control-Allow-Headers "Content-Type, Authorization"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "dev:tsc": "concurrently --names 'TSC,DOCWORKER,WEB' --prefix-colors 'yellow,blue,green' 'pnpm build:tsc:watch' 'pnpm --filter @anode/docworker dev' 'pnpm --filter @anode/web-client dev'",
     "dev:web-only": "pnpm --filter @anode/web-client dev",
     "dev:caddy": "caddy run",
-    "setup:local": "scripts/setup-local-dev.sh",
     "dev:runtime": "pnpm --filter @anode/pyodide-runtime-agent dev",
     "dev:sync-only": "pnpm --filter @anode/docworker dev",
     "setup": "node scripts/setup.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev": "concurrently --names 'DOCWORKER,WEB' --prefix-colors 'blue,green' 'pnpm --filter @anode/docworker dev' 'pnpm --filter @anode/web-client dev'",
     "dev:tsc": "concurrently --names 'TSC,DOCWORKER,WEB' --prefix-colors 'yellow,blue,green' 'pnpm build:tsc:watch' 'pnpm --filter @anode/docworker dev' 'pnpm --filter @anode/web-client dev'",
     "dev:web-only": "pnpm --filter @anode/web-client dev",
+    "dev:caddy": "caddy run",
+    "setup:local": "scripts/setup-local-dev.sh",
     "dev:runtime": "pnpm --filter @anode/pyodide-runtime-agent dev",
     "dev:sync-only": "pnpm --filter @anode/docworker dev",
     "setup": "node scripts/setup.js",

--- a/packages/docworker/src/index.ts
+++ b/packages/docworker/src/index.ts
@@ -13,6 +13,7 @@ export default {
   fetch: async (request: Request, env: any, ctx: ExecutionContext) => {
     const worker = makeWorker({
       validatePayload: (payload: any) => {
+
         if (payload?.authToken !== env.AUTH_TOKEN) {
           throw new Error('Invalid auth token')
         }

--- a/packages/docworker/wrangler.toml
+++ b/packages/docworker/wrangler.toml
@@ -33,6 +33,8 @@ DEPLOYMENT_ENV = "development"
 
 # Prototype environment (using existing database)
 [env.prototype]
+name = "anode-docworker-prototype"
+
 [[env.prototype.durable_objects.bindings]]
 name = "WEBSOCKET_SERVER"
 class_name = "WebSocketServer"

--- a/packages/web-client/src/Root.tsx
+++ b/packages/web-client/src/Root.tsx
@@ -106,7 +106,7 @@ export const App: React.FC = () => (
     )}
     batchUpdates={batchUpdates}
     storeId={storeId}
-    syncPayload={{ authToken: 'insecure-token-change-me' }}
+    syncPayload={{ authToken: import.meta.env.VITE_AUTH_TOKEN }}
   >
     <div style={{ top: 0, right: 0, position: 'absolute', background: '#333', zIndex: 50 }}>
       <FPSMeter height={40} />


### PR DESCRIPTION
- Fix web client to use VITE_AUTH_TOKEN from environment instead of hardcoded token
- Add prototype environment name override in wrangler.toml
- Remove debugging payload validation code
- Successfully deploy and test full end-to-end prototype:
  * Web client ↔ Cloudflare Worker sync working
  * Python execution via Pyodide runtime agent working
  * Real-time collaborative editing working
  * Event-sourced architecture with LiveStore working
- Add Caddyfile.example with generic IP (192.168.1.100)
- Add Caddyfile to .gitignore