### PR TITLE
Feat/simple static assets

### DIFF
--- a/packages/docworker/package.json
+++ b/packages/docworker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev --port 8787",
     "deploy": "wrangler deploy --env production",
-    "build": "echo 'CloudFlare Worker - no build needed'",
+    "build": "pnpm --filter @anode/web-client build",
     "clean": "echo 'CloudFlare Worker - no clean needed'",
     "type-check": "tsc --noEmit",
     "lint": "tsc --noEmit"

--- a/packages/docworker/wrangler.toml
+++ b/packages/docworker/wrangler.toml
@@ -12,6 +12,12 @@ name = "anode-docworker"
 main = "./src/index.ts"
 compatibility_date = "2025-05-08"
 
+# Static assets configuration - serve web client
+[assets]
+directory = "../web-client/dist"
+binding = "ASSETS"
+not_found_handling = "single-page-application"
+
 [[durable_objects.bindings]]
 name = "WEBSOCKET_SERVER"
 class_name = "WebSocketServer"
@@ -30,6 +36,10 @@ database_id = "local"
 # Environment variables (non-sensitive)
 DEPLOYMENT_ENV = "development"
 AUTH_TOKEN = "insecure-token-change-me"
+# Web client environment variables for development
+VITE_LIVESTORE_SYNC_URL = "ws://localhost:8787/api"
+VITE_GOOGLE_AUTH_ENABLED = "false"
+VITE_AUTH_TOKEN = "insecure-token-change-me"
 
 # Production/prototype environment
 [env.production]
@@ -46,6 +56,11 @@ database_id = "5339094f-f406-4236-97c3-ada460373f18"
 
 [env.production.vars]
 DEPLOYMENT_ENV = "prototype"
+# Web client environment variables
+VITE_LIVESTORE_SYNC_URL = "/api"
+VITE_GOOGLE_AUTH_ENABLED = "true"
+VITE_GOOGLE_CLIENT_ID = "94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleusercontent.com"
+VITE_AUTH_TOKEN = "insecure-token-change-me"
 
 # Secrets to be set per environment via: pnpm wrangler secret put SECRET_NAME [--env ENV_NAME]
 # For local development:

--- a/packages/docworker/wrangler.toml
+++ b/packages/docworker/wrangler.toml
@@ -60,7 +60,6 @@ DEPLOYMENT_ENV = "prototype"
 VITE_LIVESTORE_SYNC_URL = "/api"
 VITE_GOOGLE_AUTH_ENABLED = "true"
 VITE_GOOGLE_CLIENT_ID = "94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleusercontent.com"
-VITE_AUTH_TOKEN = "insecure-token-change-me"
 
 # Secrets to be set per environment via: pnpm wrangler secret put SECRET_NAME [--env ENV_NAME]
 # For local development:


### PR DESCRIPTION
Minimal change to enable serving both API and web client from single Worker:

- Add [assets] config to docworker wrangler.toml
- Route /api/* requests to LiveStore worker
- Route everything else to static assets (React app)
- Configure SPA routing with not_found_handling
- Build web client as part of docworker build process
- Set environment-specific VITE_LIVESTORE_SYNC_URL