### PR TITLE
Fix mobile keyboard autocorrect in code and SQL cells

### DIFF
--- a/packages/web-client/src/components/notebook/Cell.tsx
+++ b/packages/web-client/src/components/notebook/Cell.tsx
@@ -482,6 +482,10 @@ export const Cell: React.FC<CellProps> = ({
                 }
                 className="min-h-[2rem] sm:min-h-[1.5rem] resize-none border-0 px-2 py-2 sm:py-1 focus-visible:ring-0 font-mono bg-white w-full placeholder:text-muted-foreground/60 shadow-none text-base sm:text-sm"
                 onFocus={handleFocus}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
               />
             </div>
           </div>

--- a/packages/web-client/src/components/notebook/SqlCell.tsx
+++ b/packages/web-client/src/components/notebook/SqlCell.tsx
@@ -428,6 +428,10 @@ export const SqlCell: React.FC<SqlCellProps> = ({
                 placeholder="SELECT * FROM your_table WHERE condition = 'value';"
                 className="min-h-[1.5rem] resize-none border-0 px-2 py-1 focus-visible:ring-0 font-mono bg-white w-full placeholder:text-muted-foreground/60 shadow-none"
                 onFocus={handleFocus}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
               />
             </div>
           </div>


### PR DESCRIPTION
- Add autoCapitalize='off', autoCorrect='off', autoComplete='off', spellCheck={false} to Code and SQL cell textareas
- Prevents mobile Safari/browsers from capitalizing keywords like 'import' → 'Import'
- Maintains normal text behavior for AI cells since they use natural language
- Improves mobile coding experience without affecting desktop usage