### PR TITLE
Integrate streaming output functionality from runt

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite --port 5173",
     "dev:sync": "wrangler dev",
-    "dev:runtime": "deno run --allow-all --env-file=.env \"jsr:@runt/pyodide-runtime-agent@0.2.0\"",
+    "dev:runtime": "cd ../runt && deno run --allow-all --env-file=../anode/.env packages/pyodide-runtime-agent/src/mod.ts",
     "build": "tsc && vite build",
     "build:prod": "NODE_ENV=production tsc && vite build",
     "build:dev": "NODE_ENV=development tsc && vite build",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@runt/schema": "jsr:^0.2.0",
+    "@runt/schema": "file:../../runtimed/runt/packages/schema",
     "@types/react-syntax-highlighter": "^15.5.13",
     "ansi-to-react": "^6.1.6",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^1.1.6
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@runt/schema':
-        specifier: jsr:^0.2.0
-        version: '@jsr/runt__schema@0.2.0(c8a6ab75252475c2bbdc72175802283e)'
+        specifier: file:../../runtimed/runt/packages/schema
+        version: file:../../runtimed/runt/packages/schema(c8a6ab75252475c2bbdc72175802283e)
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
@@ -1679,6 +1679,9 @@ packages:
     resolution: {integrity: sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==}
     cpu: [x64]
     os: [win32]
+
+  '@runt/schema@file:../../runtimed/runt/packages/schema':
+    resolution: {directory: ../../runtimed/runt/packages/schema, type: directory}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -4540,6 +4543,26 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.43.0':
     optional: true
+
+  '@runt/schema@file:../../runtimed/runt/packages/schema(c8a6ab75252475c2bbdc72175802283e)':
+    dependencies:
+      '@livestore/livestore': 0.3.1(c8a6ab75252475c2bbdc72175802283e)
+    transitivePeerDependencies:
+      - '@effect/cli'
+      - '@effect/cluster'
+      - '@effect/experimental'
+      - '@effect/opentelemetry'
+      - '@effect/platform'
+      - '@effect/platform-browser'
+      - '@effect/platform-bun'
+      - '@effect/platform-node'
+      - '@effect/printer'
+      - '@effect/printer-ansi'
+      - '@effect/rpc'
+      - '@effect/sql'
+      - '@effect/typeclass'
+      - '@opentelemetry/resources'
+      - effect
 
   '@standard-schema/spec@1.0.0': {}
 


### PR DESCRIPTION
Links to local runt development version to enable testing of new streaming output methods.

Changes:
- Link @runt/schema to local file path for development
- Update dev:runtime command to use local ../runt development version
- Enables testing of displayAppend, displayReplace, and raw streaming methods

This PR pairs with the runt streaming output implementation to provide real-time AI response streaming and more efficient token-by-token updates.