### PR TITLE
Fix/home end keys in cells

### DIFF
--- a/src/components/notebook/AiCell.tsx
+++ b/src/components/notebook/AiCell.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { useStore } from "@livestore/react";
 import { events, isErrorOutput, OutputData, tables } from "@runt/schema";
 import { queryDb } from "@livestore/livestore";
+import { useCellKeyboardNavigation } from "../../hooks/useCellKeyboardNavigation.js";
+import { useCellContent } from "../../hooks/useCellContent.js";
 import { groupConsecutiveStreamOutputs } from "../../util/output-grouping.js";
 
 import { Button } from "@/components/ui/button";
@@ -57,7 +59,6 @@ export const AiCell: React.FC<AiCellProps> = ({
   contextSelectionMode = false,
 }) => {
   const { store } = useStore();
-  const [localSource, setLocalSource] = useState(cell.source);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   // Create stable query using useMemo to prevent React Hook issues
@@ -77,22 +78,11 @@ export const AiCell: React.FC<AiCellProps> = ({
     }
   }, [autoFocus]);
 
-  // Sync local source with cell source
-  React.useEffect(() => {
-    setLocalSource(cell.source);
-  }, [cell.source]);
-
-  const updateSource = useCallback(() => {
-    if (localSource !== cell.source) {
-      store.commit(
-        events.cellSourceChanged({
-          id: cell.id,
-          source: localSource,
-          modifiedBy: "current-user",
-        }),
-      );
-    }
-  }, [localSource, cell.source, cell.id, store]);
+  // Use shared content management hook
+  const { localSource, updateSource, handleSourceChange } = useCellContent({
+    cellId: cell.id,
+    initialSource: cell.source,
+  });
 
   const executeAiPrompt = useCallback(async () => {
     // Use localSource instead of cell.source to get the current typed content
@@ -160,63 +150,13 @@ export const AiCell: React.FC<AiCellProps> = ({
     }
   }, [cell.id, localSource, cell.executionCount, store]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const textarea = e.currentTarget;
-      const { selectionStart, selectionEnd, value } = textarea;
-
-      // Handle Home/End keys to prevent page navigation
-      if (e.key === "Home" || e.key === "End") {
-        // Let the textarea handle Home/End internally, but stop propagation to prevent page scroll
-        e.stopPropagation();
-        return;
-      }
-
-      // Handle arrow key navigation between cells
-      if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
-        // For empty cells or cursor at beginning of first line
-        const beforeCursor = value.substring(0, selectionStart);
-        const isAtTop = selectionStart === 0 || !beforeCursor.includes("\n");
-
-        if (isAtTop && onFocusPrevious) {
-          e.preventDefault();
-          updateSource();
-          onFocusPrevious();
-          return;
-        }
-      } else if (e.key === "ArrowDown" && selectionStart === selectionEnd) {
-        // For empty cells or cursor at end of last line
-        const afterCursor = value.substring(selectionEnd);
-        const isAtBottom = selectionEnd === value.length ||
-          !afterCursor.includes("\n");
-
-        if (isAtBottom && onFocusNext) {
-          e.preventDefault();
-          updateSource();
-          onFocusNext();
-          return;
-        }
-      }
-
-      // Handle execution shortcuts
-      if (e.key === "Enter" && e.shiftKey) {
-        // Shift+Enter: Run cell and move to next (or create new cell if at end)
-        e.preventDefault();
-        updateSource();
-        executeAiPrompt();
-        if (onFocusNext) {
-          onFocusNext(); // Move to next cell (or create new if at end)
-        }
-      } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-        // Ctrl/Cmd+Enter: Run cell but stay in current cell
-        e.preventDefault();
-        updateSource();
-        executeAiPrompt();
-        // Don't call onAddCell() - stay in current cell
-      }
-    },
-    [updateSource, executeAiPrompt, onAddCell, onFocusNext, onFocusPrevious],
-  );
+  // Use shared keyboard navigation hook
+  const { handleKeyDown } = useCellKeyboardNavigation({
+    onFocusNext,
+    onFocusPrevious,
+    onExecute: executeAiPrompt,
+    onUpdateSource: updateSource,
+  });
 
   const handleFocus = useCallback(() => {
     if (onFocus) {
@@ -617,8 +557,7 @@ export const AiCell: React.FC<AiCellProps> = ({
                 <Textarea
                   ref={textareaRef}
                   value={localSource}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    setLocalSource(e.target.value)}
+                  onChange={handleSourceChange}
                   onBlur={updateSource}
                   onKeyDown={handleKeyDown}
                   placeholder="Ask me anything about your notebook, data, or analysis..."
@@ -682,8 +621,7 @@ export const AiCell: React.FC<AiCellProps> = ({
               <Textarea
                 ref={textareaRef}
                 value={localSource}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setLocalSource(e.target.value)}
+                onChange={handleSourceChange}
                 onBlur={updateSource}
                 onKeyDown={handleKeyDown}
                 placeholder="Ask me anything about your notebook, data, or analysis..."

--- a/src/components/notebook/AiCell.tsx
+++ b/src/components/notebook/AiCell.tsx
@@ -165,6 +165,13 @@ export const AiCell: React.FC<AiCellProps> = ({
       const textarea = e.currentTarget;
       const { selectionStart, selectionEnd, value } = textarea;
 
+      // Handle Home/End keys to prevent page navigation
+      if (e.key === "Home" || e.key === "End") {
+        // Let the textarea handle Home/End internally, but stop propagation to prevent page scroll
+        e.stopPropagation();
+        return;
+      }
+
       // Handle arrow key navigation between cells
       if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
         // For empty cells or cursor at beginning of first line

--- a/src/components/notebook/Cell.tsx
+++ b/src/components/notebook/Cell.tsx
@@ -244,6 +244,13 @@ export const Cell: React.FC<CellProps> = ({
       const textarea = e.currentTarget;
       const { selectionStart, selectionEnd, value } = textarea;
 
+      // Handle Home/End keys to prevent page navigation
+      if (e.key === "Home" || e.key === "End") {
+        // Let the textarea handle Home/End internally, but stop propagation to prevent page scroll
+        e.stopPropagation();
+        return;
+      }
+
       // Handle arrow key navigation between cells
       if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
         // For empty cells or cursor at beginning of first line

--- a/src/components/notebook/Cell.tsx
+++ b/src/components/notebook/Cell.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { useStore } from "@livestore/react";
 import { events, isErrorOutput, OutputData, tables } from "@runt/schema";
 import { queryDb } from "@livestore/livestore";
+import { useCellKeyboardNavigation } from "../../hooks/useCellKeyboardNavigation.js";
+import { useCellContent } from "../../hooks/useCellContent.js";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -100,7 +102,6 @@ export const Cell: React.FC<CellProps> = ({
 
   // Default cell component for code, markdown, raw
   const { store } = useStore();
-  const [localSource, setLocalSource] = useState(cell.source);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   // Create stable query using useMemo to prevent React Hook issues
@@ -117,22 +118,11 @@ export const Cell: React.FC<CellProps> = ({
     }
   }, [autoFocus]);
 
-  // Sync local source with cell source
-  React.useEffect(() => {
-    setLocalSource(cell.source);
-  }, [cell.source]);
-
-  const updateSource = useCallback(() => {
-    if (localSource !== cell.source) {
-      store.commit(
-        events.cellSourceChanged({
-          id: cell.id,
-          source: localSource,
-          modifiedBy: "current-user", // TODO: get from auth
-        }),
-      );
-    }
-  }, [localSource, cell.source, cell.id, store]);
+  // Use shared content management hook
+  const { localSource, updateSource, handleSourceChange } = useCellContent({
+    cellId: cell.id,
+    initialSource: cell.source,
+  });
 
   const changeCellType = useCallback(
     (newType: "code" | "markdown" | "sql" | "ai") => {
@@ -239,74 +229,13 @@ export const Cell: React.FC<CellProps> = ({
     }
   }, [cell.id, localSource, cell.executionCount, store]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const textarea = e.currentTarget;
-      const { selectionStart, selectionEnd, value } = textarea;
-
-      // Handle Home/End keys to prevent page navigation
-      if (e.key === "Home" || e.key === "End") {
-        // Let the textarea handle Home/End internally, but stop propagation to prevent page scroll
-        e.stopPropagation();
-        return;
-      }
-
-      // Handle arrow key navigation between cells
-      if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
-        // For empty cells or cursor at beginning of first line
-        const beforeCursor = value.substring(0, selectionStart);
-        const isAtTop = selectionStart === 0 || !beforeCursor.includes("\n");
-
-        if (isAtTop && onFocusPrevious) {
-          e.preventDefault();
-          updateSource();
-          onFocusPrevious();
-          return;
-        }
-      } else if (e.key === "ArrowDown" && selectionStart === selectionEnd) {
-        // For empty cells or cursor at end of last line
-        const afterCursor = value.substring(selectionEnd);
-        const isAtBottom = selectionEnd === value.length ||
-          !afterCursor.includes("\n");
-
-        if (isAtBottom && onFocusNext) {
-          e.preventDefault();
-          updateSource();
-          onFocusNext();
-          return;
-        }
-      }
-
-      // Handle execution shortcuts
-      if (e.key === "Enter" && e.shiftKey) {
-        // Shift+Enter: Run cell and move to next (or create new cell if at end)
-        e.preventDefault();
-        updateSource();
-        if (cell.cellType === "code") {
-          executeCell();
-        }
-        if (onFocusNext) {
-          onFocusNext(); // Move to next cell (or create new if at end)
-        }
-      } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-        // Ctrl/Cmd+Enter: Run cell but stay in current cell
-        e.preventDefault();
-        updateSource();
-        if (cell.cellType === "code") {
-          executeCell();
-        }
-        // Don't call onAddCell() - stay in current cell
-      }
-    },
-    [
-      updateSource,
-      executeCell,
-      cell.cellType,
-      onAddCell,
-      onFocusNext,
-      onFocusPrevious,
-    ],
-  );
+  // Use shared keyboard navigation hook
+  const { handleKeyDown } = useCellKeyboardNavigation({
+    onFocusNext,
+    onFocusPrevious,
+    onExecute: cell.cellType === "code" ? executeCell : undefined,
+    onUpdateSource: updateSource,
+  });
 
   const handleFocus = useCallback(() => {
     if (onFocus) {
@@ -593,8 +522,7 @@ export const Cell: React.FC<CellProps> = ({
               <Textarea
                 ref={textareaRef}
                 value={localSource}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  setLocalSource(e.target.value)}
+                onChange={handleSourceChange}
                 onBlur={updateSource}
                 onKeyDown={handleKeyDown}
                 placeholder={cell.cellType === "code"

--- a/src/components/notebook/SqlCell.tsx
+++ b/src/components/notebook/SqlCell.tsx
@@ -117,6 +117,13 @@ export const SqlCell: React.FC<SqlCellProps> = ({
       const textarea = e.currentTarget;
       const { selectionStart, selectionEnd, value } = textarea;
 
+      // Handle Home/End keys to prevent page navigation
+      if (e.key === "Home" || e.key === "End") {
+        // Let the textarea handle Home/End internally, but stop propagation to prevent page scroll
+        e.stopPropagation();
+        return;
+      }
+
       // Handle arrow key navigation between cells
       if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
         // For empty cells or cursor at beginning of first line

--- a/src/hooks/useCellContent.ts
+++ b/src/hooks/useCellContent.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react";
+import { useStore } from "@livestore/react";
+import { events } from "@runt/schema";
+
+interface CellContentOptions {
+  cellId: string;
+  initialSource: string;
+  onUpdate?: (source: string) => void;
+}
+
+export const useCellContent = ({
+  cellId,
+  initialSource,
+  onUpdate,
+}: CellContentOptions) => {
+  const { store } = useStore();
+  const [localSource, setLocalSource] = useState(initialSource);
+
+  // Sync local source with cell source
+  useEffect(() => {
+    setLocalSource(initialSource);
+  }, [initialSource]);
+
+  const updateSource = useCallback(() => {
+    if (localSource !== initialSource) {
+      store.commit(
+        events.cellSourceChanged({
+          id: cellId,
+          source: localSource,
+          modifiedBy: "current-user", // TODO: get from auth
+        }),
+      );
+      onUpdate?.(localSource);
+    }
+  }, [localSource, initialSource, cellId, store, onUpdate]);
+
+  const handleSourceChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setLocalSource(e.target.value);
+    },
+    [],
+  );
+
+  return {
+    localSource,
+    setLocalSource,
+    updateSource,
+    handleSourceChange,
+  };
+};

--- a/src/hooks/useCellKeyboardNavigation.ts
+++ b/src/hooks/useCellKeyboardNavigation.ts
@@ -1,0 +1,75 @@
+import { useCallback } from "react";
+
+interface CellKeyboardNavigationOptions {
+  onFocusNext?: () => void;
+  onFocusPrevious?: () => void;
+  onExecute?: () => void;
+  onUpdateSource?: () => void;
+}
+
+export const useCellKeyboardNavigation = ({
+  onFocusNext,
+  onFocusPrevious,
+  onExecute,
+  onUpdateSource,
+}: CellKeyboardNavigationOptions) => {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const textarea = e.currentTarget;
+      const { selectionStart, selectionEnd, value } = textarea;
+
+      // Handle Home/End keys to prevent page navigation
+      if (e.key === "Home" || e.key === "End") {
+        // Let the textarea handle Home/End internally, but stop propagation to prevent page scroll
+        e.stopPropagation();
+        return;
+      }
+
+      // Handle arrow key navigation between cells
+      if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
+        // For empty cells or cursor at beginning of first line
+        const beforeCursor = value.substring(0, selectionStart);
+        const isAtTop = selectionStart === 0 || !beforeCursor.includes("\n");
+
+        if (isAtTop && onFocusPrevious) {
+          e.preventDefault();
+          onUpdateSource?.();
+          onFocusPrevious();
+          return;
+        }
+      } else if (e.key === "ArrowDown" && selectionStart === selectionEnd) {
+        // For empty cells or cursor at end of last line
+        const afterCursor = value.substring(selectionEnd);
+        const isAtBottom = selectionEnd === value.length ||
+          !afterCursor.includes("\n");
+
+        if (isAtBottom && onFocusNext) {
+          e.preventDefault();
+          onUpdateSource?.();
+          onFocusNext();
+          return;
+        }
+      }
+
+      // Handle execution shortcuts
+      if (e.key === "Enter" && e.shiftKey) {
+        // Shift+Enter: Run cell and move to next (or create new cell if at end)
+        e.preventDefault();
+        onUpdateSource?.();
+        onExecute?.();
+        if (onFocusNext) {
+          onFocusNext(); // Move to next cell (or create new if at end)
+        }
+      } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        // Ctrl/Cmd+Enter: Run cell but stay in current cell
+        e.preventDefault();
+        onUpdateSource?.();
+        onExecute?.();
+        // Don't move to next cell - stay in current cell
+      }
+    },
+    [onFocusNext, onFocusPrevious, onExecute, onUpdateSource],
+  );
+
+  return { handleKeyDown };
+};


### PR DESCRIPTION
## Problem
- Home/End keys in cell text areas were jumping around the page instead of working within the textarea
- ~150 lines of duplicated keyboard handling code across Cell, AiCell, and SqlCell components

## Solution
### Fixed Home/End Key Navigation ✅
- Added proper event handling to prevent page navigation
- Keys now work correctly within text areas for all cell types

### Extracted Shared Cell Behavior 🏗️
Created two reusable hooks:

**`useCellKeyboardNavigation`:**
- Home/End key prevention of page navigation  
- Arrow key navigation between cells (Up/Down at boundaries)
- Execution shortcuts (Shift+Enter, Ctrl/Cmd+Enter)

**`useCellContent`:**
- Local state management with sync to cell source
- Textarea change handling
- Source update logic with LiveStore commits

### Benefits 📈
- **Eliminated ~150 lines of duplicated code** across cell components
- **Single source of truth** for cell keyboard behavior  
- **Consistent behavior** across all cell types
- **Future-ready** for CodeMirror integration
- **Maintained mobile-friendly** plain textarea approach

## Architecture Impact
This modular approach prepares the codebase for:
- Easy addition of new cell types using these hooks
- Future CodeMirror integration without major refactoring
- Centralized behavior changes that apply to all cells
- Better testability through hook isolation
