### PR TITLE
fix: remove height limit from image outputs

### DIFF
--- a/src/components/outputs/ImageOutput.tsx
+++ b/src/components/outputs/ImageOutput.tsx
@@ -52,7 +52,7 @@ export const ImageOutput: React.FC<ImageOutputProps> = ({
           src={imageSrc}
           alt={alt}
           className="zoomable-image h-auto max-w-full cursor-zoom-in transition-opacity hover:opacity-90"
-          style={{ maxHeight: "400px", objectFit: "contain" }}
+          style={{ objectFit: "contain" }}
           onClick={() => setZoomedImage(imageSrc)}
         />
         <div className="bg-opacity-50 absolute top-2 right-2 rounded bg-black p-1 text-white opacity-0 transition-opacity group-hover:opacity-100">


### PR DESCRIPTION
Simple fix for #84 - removes hardcoded 400px maxHeight from ImageOutput component.

**Change:** Remove maxHeight: 400px style constraint
**Result:** Images display at full natural size
**Preserves:** Zoom functionality and responsive max-width

Fixes #84