### PR TITLE
Enhance mobile textarea experience and clean up UI

### DIFF
--- a/src/components/notebook/Cell.tsx
+++ b/src/components/notebook/Cell.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { useStore } from "@livestore/react";
 import { events, isErrorOutput, OutputData, tables } from "@runt/schema";
 import { queryDb } from "@livestore/livestore";
@@ -31,6 +31,8 @@ import {
   Eye,
   EyeOff,
   FileText,
+  Maximize2,
+  Minimize2,
   Play,
   Plus,
   X,
@@ -103,6 +105,7 @@ export const Cell: React.FC<CellProps> = ({
   // Default cell component for code, markdown, raw
   const { store } = useStore();
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const [isMaximized, setIsMaximized] = useState(false);
 
   // Create stable query using useMemo to prevent React Hook issues
   const outputsQuery = React.useMemo(
@@ -527,7 +530,7 @@ export const Cell: React.FC<CellProps> = ({
               autoFocus ? "bg-white" : "bg-white"
             }`}
           >
-            <div className="min-h-[1.5rem]">
+            <div className="relative min-h-[1.5rem]">
               <Textarea
                 ref={textareaRef}
                 value={localSource}
@@ -541,13 +544,39 @@ export const Cell: React.FC<CellProps> = ({
                       ? "Enter markdown..."
                       : "Enter raw text..."
                 }
-                className="placeholder:text-muted-foreground/60 min-h-[2rem] w-full resize-none border-0 bg-white px-2 py-2 font-mono text-base shadow-none focus-visible:ring-0 sm:min-h-[1.5rem] sm:py-1 sm:text-sm"
+                className={`placeholder:text-muted-foreground/60 w-full resize-none border-0 bg-white px-2 py-2 font-mono text-base shadow-none transition-all duration-200 focus-visible:ring-0 sm:py-1 sm:text-sm ${
+                  isMaximized
+                    ? "fixed inset-4 top-16 z-50 max-h-[calc(100vh-8rem)] min-h-[calc(100vh-8rem)] rounded-lg border bg-white shadow-2xl"
+                    : "max-h-[50vh] min-h-[50vh] sm:max-h-none sm:min-h-[1.5rem]"
+                }`}
                 onFocus={handleFocus}
                 autoCapitalize="off"
                 autoCorrect="off"
                 autoComplete="off"
                 spellCheck={false}
               />
+
+              {/* Mobile maximize/minimize button */}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="absolute top-1 right-1 h-6 w-6 p-1 sm:hidden"
+                onClick={() => setIsMaximized(!isMaximized)}
+              >
+                {isMaximized ? (
+                  <Minimize2 className="h-3 w-3" />
+                ) : (
+                  <Maximize2 className="h-3 w-3" />
+                )}
+              </Button>
+
+              {/* Overlay for maximized mode */}
+              {isMaximized && (
+                <div
+                  className="fixed inset-0 z-40 bg-black/20 sm:hidden"
+                  onClick={() => setIsMaximized(false)}
+                />
+              )}
             </div>
           </div>
         )}

--- a/src/components/notebook/Cell.tsx
+++ b/src/components/notebook/Cell.tsx
@@ -547,7 +547,7 @@ export const Cell: React.FC<CellProps> = ({
                 className={`placeholder:text-muted-foreground/60 w-full resize-none border-0 bg-white px-2 py-2 font-mono text-base shadow-none transition-all duration-200 focus-visible:ring-0 sm:py-1 sm:text-sm ${
                   isMaximized
                     ? "fixed inset-4 top-16 z-50 max-h-[calc(100vh-8rem)] min-h-[calc(100vh-8rem)] rounded-lg border bg-white shadow-2xl"
-                    : "max-h-[50vh] min-h-[50vh] sm:max-h-none sm:min-h-[1.5rem]"
+                    : "max-h-[40vh] min-h-[8rem] sm:max-h-none sm:min-h-[1.5rem]"
                 }`}
                 onFocus={handleFocus}
                 autoCapitalize="off"

--- a/src/components/notebook/Cell.tsx
+++ b/src/components/notebook/Cell.tsx
@@ -547,7 +547,7 @@ export const Cell: React.FC<CellProps> = ({
                 className={`placeholder:text-muted-foreground/60 w-full resize-none border-0 bg-white px-2 py-2 font-mono text-base shadow-none transition-all duration-200 focus-visible:ring-0 sm:py-1 sm:text-sm ${
                   isMaximized
                     ? "fixed inset-4 top-16 z-50 max-h-[calc(100vh-8rem)] min-h-[calc(100vh-8rem)] rounded-lg border bg-white shadow-2xl"
-                    : "max-h-[40vh] min-h-[8rem] sm:max-h-none sm:min-h-[1.5rem]"
+                    : "max-h-[40vh] min-h-[2.5rem] sm:max-h-none sm:min-h-[1.5rem]"
                 }`}
                 onFocus={handleFocus}
                 autoCapitalize="off"

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -824,19 +824,12 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                       AI
                     </Button>
                   </div>
-                  <div className="text-muted-foreground mt-2 text-xs">
+                  <div className="text-muted-foreground mt-2 hidden text-xs sm:block">
                     Add a new cell
                   </div>
                 </div>
               </div>
             )}
-
-            {/* Notebook Info */}
-            <div className="border-border/30 mt-8 border-t px-4 pt-4 sm:mt-12 sm:px-0 sm:pt-6">
-              <div className="text-muted-foreground text-center text-xs">
-                Owner: {notebook.ownerId}
-              </div>
-            </div>
           </div>
         </div>
 

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -749,7 +749,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                       AI Assistant
                     </Button>
                   </div>
-                  <div className="text-muted-foreground text-xs">
+                  <div className="text-muted-foreground hidden text-xs sm:block">
                     💡 Use ↑↓ arrow keys to navigate • Shift+Enter to run and
                     move • Ctrl+Enter to run
                   </div>


### PR DESCRIPTION
Improves mobile experience by enhancing textarea sizing and removing extraneous UI elements.

![scroll](https://github.com/user-attachments/assets/ecffaafa-d63a-42ce-924e-57aec15defd4)

## Changes

**Textarea Improvements:**
- Mobile textarea now starts at single line height (~2.5rem) instead of wasting space
- Grows intelligently with content up to 40vh maximum height
- Added maximize/minimize button for full-screen editing on mobile
- Smooth transitions and overlay for maximized mode
- Desktop experience unchanged

**UI Cleanup:**
- Hide keyboard shortcuts on mobile (saves vertical space)
- Hide 'Add a new cell' text on mobile
- Remove 'Owner: current-user' display entirely (all platforms)
- Cleaner, more focused mobile interface

## Issues Closed

Closes #105
Closes #81  
Closes #107