### PR TITLE
Fluid Document Navigation

### DIFF
--- a/src/hooks/useCellKeyboardNavigation.ts
+++ b/src/hooks/useCellKeyboardNavigation.ts
@@ -27,46 +27,80 @@ export const useCellKeyboardNavigation = ({
 
       // Handle arrow key navigation between cells
       if (e.key === "ArrowUp" && selectionStart === selectionEnd) {
-        // For empty cells or cursor at beginning of first line
+        // Check if cursor is at the beginning of the first line
         const beforeCursor = value.substring(0, selectionStart);
-        const isAtTop = selectionStart === 0 || !beforeCursor.includes("\n");
+        const currentLineIndex = beforeCursor.split("\n").length - 1;
+        const lastNewlineIndex = beforeCursor.lastIndexOf("\n");
+        const positionInLine =
+          lastNewlineIndex === -1
+            ? selectionStart
+            : selectionStart - lastNewlineIndex - 1;
 
-        if (isAtTop && onFocusPrevious) {
-          e.preventDefault();
-          onUpdateSource?.();
-          onFocusPrevious();
-          return;
+        if (currentLineIndex === 0) {
+          // We're on the first line
+          if (positionInLine === 0) {
+            // At the very beginning - move to previous cell
+            if (onFocusPrevious) {
+              e.preventDefault();
+              onUpdateSource?.();
+              onFocusPrevious();
+              return;
+            }
+          } else {
+            // Not at beginning of first line - move to beginning
+            e.preventDefault();
+            textarea.setSelectionRange(0, 0);
+            return;
+          }
         }
       } else if (e.key === "ArrowDown" && selectionStart === selectionEnd) {
-        // For empty cells or cursor at end of last line
-        const afterCursor = value.substring(selectionEnd);
-        const isAtBottom =
-          selectionEnd === value.length || !afterCursor.includes("\n");
+        // Check if cursor is at the end of the last line
+        const lines = value.split("\n");
+        const beforeCursor = value.substring(0, selectionStart);
+        const currentLineIndex = beforeCursor.split("\n").length - 1;
+        const currentLine = lines[currentLineIndex];
+        const lastNewlineIndex = beforeCursor.lastIndexOf("\n");
+        const positionInLine =
+          lastNewlineIndex === -1
+            ? selectionStart
+            : selectionStart - lastNewlineIndex - 1;
 
-        if (isAtBottom && onFocusNext) {
-          e.preventDefault();
-          onUpdateSource?.();
-          onFocusNext();
-          return;
+        if (currentLineIndex === lines.length - 1) {
+          // We're on the last line
+          if (positionInLine === currentLine.length) {
+            // At the very end - move to next cell
+            if (onFocusNext) {
+              e.preventDefault();
+              onUpdateSource?.();
+              onFocusNext();
+              return;
+            }
+          } else {
+            // Not at end of last line - move to end
+            e.preventDefault();
+            textarea.setSelectionRange(value.length, value.length);
+            return;
+          }
         }
       }
 
       // Handle execution shortcuts
-      if (e.key === "Enter" && e.shiftKey) {
-        // Shift+Enter: Run cell and move to next (or create new cell if at end)
+      if (e.key === "Enter" && e.ctrlKey && !e.metaKey) {
+        // Ctrl+Enter: Run cell but stay in current cell
+        e.preventDefault();
+        onUpdateSource?.();
+        onExecute?.();
+        // Don't move to next cell - stay in current cell
+      } else if (e.key === "Enter" && e.metaKey && !e.ctrlKey) {
+        // Cmd+Enter: Run cell and move to next (or create new cell if at end)
         e.preventDefault();
         onUpdateSource?.();
         onExecute?.();
         if (onFocusNext) {
           onFocusNext(); // Move to next cell (or create new if at end)
         }
-      } else if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-        // Ctrl/Cmd+Enter: Run cell but stay in current cell
-        e.preventDefault();
-        onUpdateSource?.();
-        onExecute?.();
-        // Don't move to next cell - stay in current cell
       }
+      // Shift+Enter now creates a newline (default behavior) - no special handling needed
     },
     [onFocusNext, onFocusPrevious, onExecute, onUpdateSource]
   );


### PR DESCRIPTION
This implements what I call "Fluid Document" keyboard navigation behavior for cells, creating a more natural editing experience similar to chat applications.

### Two-Step Navigation Pattern

**Arrow Up**: First moves to beginning of cell, then to previous cell
**Arrow Down**: First moves to end of cell, then to next cell

#### Example

Starting with cursor mid-cell:

```
import pandas as pd |
pd.read_csv("example.csv")
```

Press ↑ once cursor moves to start of current cell:

```
|import pandas as pd
pd.read_csv("example.csv")
```

Press ↑ again and the cursor moves to the previous cell.

This prevents accidental cell navigation when you're just trying to move within your code. Instead of jumping between cells unexpectedly, you get a predictable two-step process:

1. Navigate to the edge of your current content
2. Then move between cells

This matches the mental model of "finish with this cell, then move on" that people expect in document editing and chat interfaces.

### Chat-App-Style Enter Behavior

I've also done something a bit more opinionated based on how much people are using chat with code and otherwise. We're all getting used to `shift-enter` allowing us to compose more text when writing to an AI or in chat in general. However, people are used to using this with notebooks. I imagine we're going to revisit this later.

Now... shift-enter creates newlines without execution. The others stay the same.

- **Shift+Enter**: Creates newlines (no execution)
- **Ctrl+Enter**: Run cell, stay in current cell  
- **Cmd+Enter**: Run cell and move to next cell